### PR TITLE
Add YAPF config; reformat everything using it

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-ignore = E741, E226, W503
+ignore = E741, E226, W503, W504

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,2 @@
+[style]
+based_on_style = pep8

--- a/ion_phys/common.py
+++ b/ion_phys/common.py
@@ -250,7 +250,7 @@ class Ion:
         """ Use the transition data to sort the atomic levels in order of
         increasing energy.
         """
-        if not(self.transitions):
+        if not self.transitions:
             levels = list(self.levels.keys())
             if len(levels) != 1:
                 raise ValueError("Disconnected level structure.")
@@ -322,7 +322,7 @@ class Ion:
             H = data.g_J*_uB*B*Jz
             if self.I != 0:
                 gI = data.g_I
-                IdotJ = (Iz@Jz + (1/2)*(Ip@Jm + Im@Jp))
+                IdotJ = Iz@Jz + (1/2)*(Ip@Jm + Im@Jp)
 
                 H += - gI*_uN*B*Iz
                 H += data.Ahfs*IdotJ

--- a/ion_phys/common.py
+++ b/ion_phys/common.py
@@ -63,7 +63,7 @@ class LevelData:
 
     def __repr__(self):
         return ("LevelData(g_J={}, g_I={}, E={}, num_states={}, start_ind={}, "
-                " stop_ind={})""".format(self.g_J, self.g_I, self.E,
+                " stop_ind={})".format(self.g_J, self.g_I, self.E,
                                          self._num_states, self._start_ind,
                                          self._stop_ind))
 

--- a/ion_phys/examples/M1_transitions.py
+++ b/ion_phys/examples/M1_transitions.py
@@ -3,20 +3,19 @@ import scipy.constants as sc
 
 uB = sc.physical_constants['Bohr magneton'][0]
 
-
 if __name__ == '__main__':
     # all seems correct (e.g. agrees with TPH thesis table E.4)
     ion = Ca43(level_filter=[ground_level])
-    ion.setB(146.0942e-4)   # magic field for 0->1 clock qubit
+    ion.setB(146.0942e-4)  # magic field for 0->1 clock qubit
     ion.calc_M1()
 
-    R = ion.M1/uB
+    R = ion.M1 / uB
 
     for M3 in range(-3, +3 + 1):
         for q in [-1, 0, 1]:
-            F4 = ion.index(ground_level, M3-q, F=4)
+            F4 = ion.index(ground_level, M3 - q, F=4)
             F3 = ion.index(ground_level, M3, F=3)
             Rnm = R[ion.index(ground_level, M=M3, F=3),
-                    ion.index(ground_level, M=M3-q, F=4)]
+                    ion.index(ground_level, M=M3 - q, F=4)]
             print('Rnm for F=3, M={} -> F=4,'
                   'M={}: {:.6f}'.format(M3, M3 - q, Rnm))

--- a/ion_phys/examples/breit_rabi.py
+++ b/ion_phys/examples/breit_rabi.py
@@ -5,19 +5,19 @@ import matplotlib.pyplot as plt
 from ion_phys.ions.ca43 import Ca43, ground_level
 
 ion = Ca43(level_filter=[ground_level])
-idim = int(np.rint(2*ion.I+1))
-jdim = int(np.rint(2*1/2+1))
+idim = int(np.rint(2 * ion.I + 1))
+jdim = int(np.rint(2 * 1 / 2 + 1))
 
 B_ax = np.arange(0.01, 30000, 200)  # B fields (Gauss)
-energies = np.zeros((len(B_ax), idim*jdim))
+energies = np.zeros((len(B_ax), idim * jdim))
 
 for idx, B in enumerate(B_ax):
-    ion.setB(B*1e-4)
+    ion.setB(B * 1e-4)
     energies[idx, :] = ion.E
 
 plt.figure()
-for idx in range(idim*jdim):
-    plt.plot(B_ax, energies[:, idx]/(2*np.pi*1e6))
+for idx in range(idim * jdim):
+    plt.plot(B_ax, energies[:, idx] / (2 * np.pi * 1e6))
 
 plt.ylabel('Frequency (MHz)')
 plt.xlabel('B field (G)')

--- a/ion_phys/examples/ca_shelving.py
+++ b/ion_phys/examples/ca_shelving.py
@@ -23,10 +23,10 @@ def main():
     Vi[stretch] = 1  # start in F=4, M=+4
     shelved = np.zeros(len(t_ax))
     for idx, t in np.ndenumerate(t_ax):
-        Vf = expm(trans*t)@Vi
+        Vf = expm(trans * t) @ Vi
         shelved[idx] = sum(Vf[ion.slice(shelf)])
 
-    plt.plot(t_ax*1e6, shelved)
+    plt.plot(t_ax * 1e6, shelved)
     plt.ylabel('Shelved Population')
     plt.xlabel('Shelving time (us)')
     plt.grid()

--- a/ion_phys/examples/clock_qubits.py
+++ b/ion_phys/examples/clock_qubits.py
@@ -3,7 +3,6 @@ import numpy as np
 from ion_phys.ions.ca43 import Ca43, ground_level
 from ion_phys.utils import (field_insensitive_point, d2f_dB2)
 
-
 if __name__ == '__main__':
     # all seems about correct (e.g. agrees with TPH thesis) but expect some
     # numerical inaccuracy, particularly around the second-order field
@@ -15,16 +14,15 @@ if __name__ == '__main__':
     for M3 in range(-3, +3 + 1):
         for q in [-1, 0, 1]:
             ion.setB(1e-4)
-            F4 = ion.index(ground_level, M3-q, F=4)
+            F4 = ion.index(ground_level, M3 - q, F=4)
             F3 = ion.index(ground_level, M3, F=3)
             B0 = field_insensitive_point(ion, F4, F3)
             if B0 is not None:
                 ion.setB(B0)
                 f0 = ion.delta(F4, F3)
                 d2fdB2 = d2f_dB2(ion, F4, F3)
-                print(
-                    "4, {} --> 3, {}: {:.6f} GHz @ {:.5f} G ({:.3e} Hz/G^2)"
-                    .format(M3-q, M3, f0/(2*np.pi*1e6), B0*1e4,
-                            d2fdB2/(2*np.pi)*1e-8))
+                print("4, {} --> 3, {}: {:.6f} GHz @ {:.5f} G ({:.3e} Hz/G^2)".
+                      format(M3 - q, M3, f0 / (2 * np.pi * 1e6), B0 * 1e4,
+                             d2fdB2 / (2 * np.pi) * 1e-8))
             else:
-                print("4, {} --> 3, {}: none found".format(M3-q, M3))
+                print("4, {} --> 3, {}: none found".format(M3 - q, M3))

--- a/ion_phys/ions/ca40.py
+++ b/ion_phys/ions/ca40.py
@@ -7,13 +7,12 @@ import numpy as np
 import scipy.constants as consts
 from ion_phys import Level, LevelData, Transition, Ion
 
-
 # level aliases
-ground_level = S12 = Level(n=4, S=1/2, L=0, J=1/2)
-P12 = Level(n=4, S=1/2, L=1, J=1/2)
-P32 = Level(n=4, S=1/2, L=1, J=3/2)
-D32 = Level(n=4, S=1/2, L=2, J=3/2)
-shelf = D52 = Level(n=4, S=1/2, L=2, J=5/2)
+ground_level = S12 = Level(n=4, S=1 / 2, L=0, J=1 / 2)
+P12 = Level(n=4, S=1 / 2, L=1, J=1 / 2)
+P32 = Level(n=4, S=1 / 2, L=1, J=3 / 2)
+D32 = Level(n=4, S=1 / 2, L=2, J=3 / 2)
+shelf = D52 = Level(n=4, S=1 / 2, L=2, J=5 / 2)
 
 
 class Ca40(Ion):
@@ -33,49 +32,59 @@ class Ca40(Ion):
         }
 
         transitions = {
-            "397": Transition(
+            "397":
+            Transition(
                 lower=S12,
                 upper=P12,
                 A=132e6,  # [?]
-                freq=2*np.pi*755.2227662e12  # [?]
+                freq=2 * np.pi * 755.2227662e12  # [?]
             ),
-            "393": Transition(
+            "393":
+            Transition(
                 lower=S12,
                 upper=P32,
                 A=135e6,  # [?]
-                freq=2*np.pi*761.9050127e12  # [?]
+                freq=2 * np.pi * 761.9050127e12  # [?]
             ),
-            "866": Transition(
+            "866":
+            Transition(
                 lower=D32,
                 upper=P12,
                 A=8.4e6,  # [?]
-                freq=2*np.pi*consts.c/866e-9  # [?]
+                freq=2 * np.pi * consts.c / 866e-9  # [?]
             ),
-            "850": Transition(
+            "850":
+            Transition(
                 lower=D32,
                 upper=P32,
                 A=0.955e6,  # [?]
-                freq=2*np.pi*consts.c/850e-9  # [?]
+                freq=2 * np.pi * consts.c / 850e-9  # [?]
             ),
-            "854": Transition(
+            "854":
+            Transition(
                 lower=D52,
                 upper=P32,
                 A=8.48e6,  # [?]
-                freq=2*np.pi*consts.c/854e-9  # [?]
+                freq=2 * np.pi * consts.c / 854e-9  # [?]
             ),
-            "729": Transition(
+            "729":
+            Transition(
                 lower=S12,
                 upper=D52,
                 A=0.856,  # [?]
-                freq=411.0421297763932e12*2*np.pi  # [?]
+                freq=411.0421297763932e12 * 2 * np.pi  # [?]
             ),
-            "733": Transition(
+            "733":
+            Transition(
                 lower=S12,
                 upper=D32,
                 A=0.850,  # [?]
-                freq=409.222e12*2*np.pi  # [?]
+                freq=409.222e12 * 2 * np.pi  # [?]
             ),
         }
 
-        super().__init__(B=B, I=0, levels=levels, transitions=transitions,
+        super().__init__(B=B,
+                         I=0,
+                         levels=levels,
+                         transitions=transitions,
                          level_filter=level_filter)

--- a/ion_phys/ions/ca43.py
+++ b/ion_phys/ions/ca43.py
@@ -15,13 +15,12 @@ import numpy as np
 import scipy.constants as consts
 from ion_phys import Level, LevelData, Transition, Ion
 
-
 # level aliases
-ground_level = S12 = Level(n=4, S=1/2, L=0, J=1/2)
-P12 = Level(n=4, S=1/2, L=1, J=1/2)
-P32 = Level(n=4, S=1/2, L=1, J=3/2)
-D32 = Level(n=4, S=1/2, L=2, J=3/2)
-shelf = D52 = Level(n=4, S=1/2, L=2, J=5/2)
+ground_level = S12 = Level(n=4, S=1 / 2, L=0, J=1 / 2)
+P12 = Level(n=4, S=1 / 2, L=1, J=1 / 2)
+P32 = Level(n=4, S=1 / 2, L=1, J=3 / 2)
+D32 = Level(n=4, S=1 / 2, L=2, J=3 / 2)
+shelf = D52 = Level(n=4, S=1 / 2, L=2, J=5 / 2)
 
 
 class Ca43(Ion):
@@ -33,26 +32,31 @@ class Ca43(Ion):
             None we include all levels.
         """
         levels = {
-            ground_level: LevelData(
+            ground_level:
+            LevelData(
                 g_J=2.00225664,  # [2]
                 g_I=(2 / 7) * -1.315348,  # [3]
                 Ahfs=-3225.60828640e6 * consts.h / 4  # [1]
             ),
-            P12: LevelData(
+            P12:
+            LevelData(
                 Ahfs=-145.4e6 * consts.h,  # [4]
                 g_I=(2 / 7) * -1.315348  # [3]
             ),
-            P32: LevelData(
+            P32:
+            LevelData(
                 Ahfs=-31.4e6 * consts.h,  # [4]
                 Bhfs=-6.9 * consts.h,  # [4]
                 g_I=(2 / 7) * -1.315348  # [3]
             ),
-            D32: LevelData(
+            D32:
+            LevelData(
                 Ahfs=-47.3e6 * consts.h,  # [4]
                 Bhfs=-3.7 * consts.h,  # [4]
                 g_I=(2 / 7) * -1.315348  # [3]
             ),
-            D52: LevelData(
+            D52:
+            LevelData(
                 Ahfs=-3.8931e6 * consts.h,  # [5]
                 Bhfs=4.241 * consts.h,  # [5]
                 g_I=(2 / 7) * -1.315348  # [3]
@@ -60,49 +64,59 @@ class Ca43(Ion):
         }
 
         transitions = {
-            "397": Transition(
+            "397":
+            Transition(
                 lower=S12,
                 upper=P12,
                 A=132e6,  # [?]
-                freq=2*np.pi*755.2227662e12  # [?]
+                freq=2 * np.pi * 755.2227662e12  # [?]
             ),
-            "393": Transition(
+            "393":
+            Transition(
                 lower=S12,
                 upper=P32,
                 A=135e6,  # [?]
-                freq=2*np.pi*761.9050127e12  # [?]
+                freq=2 * np.pi * 761.9050127e12  # [?]
             ),
-            "866": Transition(
+            "866":
+            Transition(
                 lower=D32,
                 upper=P12,
                 A=8.4e6,  # [?]
-                freq=2*np.pi*consts.c/866e-9  # [?]
+                freq=2 * np.pi * consts.c / 866e-9  # [?]
             ),
-            "850": Transition(
+            "850":
+            Transition(
                 lower=D32,
                 upper=P32,
                 A=0.955e6,  # [?]
-                freq=2*np.pi*consts.c/850e-9  # [?]
+                freq=2 * np.pi * consts.c / 850e-9  # [?]
             ),
-            "854": Transition(
+            "854":
+            Transition(
                 lower=D52,
                 upper=P32,
                 A=8.48e6,  # [?]
-                freq=2*np.pi*consts.c/854e-9  # [?]
+                freq=2 * np.pi * consts.c / 854e-9  # [?]
             ),
-            "729": Transition(
+            "729":
+            Transition(
                 lower=S12,
                 upper=D52,
                 A=0.856,  # [?]
-                freq=411.0421297763932e12*2*np.pi  # [?]
+                freq=411.0421297763932e12 * 2 * np.pi  # [?]
             ),
-            "733": Transition(
+            "733":
+            Transition(
                 lower=S12,
                 upper=D32,
                 A=0.850,  # [?]
-                freq=409.222e12*2*np.pi  # [?]
+                freq=409.222e12 * 2 * np.pi  # [?]
             ),
         }
 
-        super().__init__(B=B, I=7/2, levels=levels, transitions=transitions,
+        super().__init__(B=B,
+                         I=7 / 2,
+                         levels=levels,
+                         transitions=transitions,
                          level_filter=level_filter)

--- a/ion_phys/operators.py
+++ b/ion_phys/operators.py
@@ -14,7 +14,7 @@ def Jp(j):
       J+1 = -1/(sqrt(2)) J+
     """
     Mj = np.arange(-j, j)
-    return np.diag(np.sqrt((j-Mj)*(j+Mj+1)), -1)
+    return np.diag(np.sqrt((j - Mj) * (j + Mj + 1)), -1)
 
 
 def Jm(j):
@@ -37,5 +37,5 @@ def Jz(j):
     The returned operator is defined so that:
       Jp[Mi,Mj] := <Mi|Jz|Mj> = Mi*delta(Mi,Mj+1)
     """
-    Mj = np.arange(-j, j+1)
+    Mj = np.arange(-j, j + 1)
     return np.diag(Mj)

--- a/ion_phys/rate_equations.py
+++ b/ion_phys/rate_equations.py
@@ -22,8 +22,9 @@ class Rates:
         stim = np.zeros(Gamma.shape)
 
         for transition in self.ion.transitions.keys():
-            _lasers = [laser for laser in lasers
-                       if laser.transition == transition]
+            _lasers = [
+                laser for laser in lasers if laser.transition == transition
+            ]
             if _lasers == []:
                 continue
 
@@ -34,7 +35,7 @@ class Rates:
             n_lower = self.ion.levels[lower]._num_states
             n_upper = self.ion.levels[upper]._num_states
 
-            dJ = upper.J-lower.J
+            dJ = upper.J - lower.J
             dL = upper.L - lower.L
             if dJ in [-1, 0, +1] and dL in [-1, 0, +1]:
                 order = 1
@@ -60,21 +61,21 @@ class Rates:
 
             # Total scattering rate out of each state
             GammaJ_subs = GammaJ[upper_states]
-            GammaJ_subs = np.repeat(GammaJ_subs, n_lower).reshape(
-                n_upper, n_lower).T
+            GammaJ_subs = np.repeat(GammaJ_subs,
+                                    n_lower).reshape(n_upper, n_lower).T
             GammaJ2 = np.power(GammaJ_subs, 2)
 
             Gamma_subs = Gamma[lower_states, upper_states]
             R = np.zeros((n_lower, n_upper))
-            for q in range(-order, order+1):
+            for q in range(-order, order + 1):
                 Q = np.zeros((n_lower, n_upper))
                 # q := Mu - Ml
-                Q[Ml == (Mu-q)] = 1
+                Q[Ml == (Mu - q)] = 1
                 for laser in [laser for laser in _lasers if laser.q == q]:
                     delta = delta_lu - laser.delta
                     I = laser.I
-                    R += (GammaJ2/(4*np.power(delta, 2) + GammaJ2)
-                          * I*(Q*Gamma_subs))
+                    R += (GammaJ2 / (4 * np.power(delta, 2) + GammaJ2) * I *
+                          (Q * Gamma_subs))
                 assert (R >= 0).all()
 
             stim[lower_states, upper_states] = R

--- a/ion_phys/tests/test_rates.py
+++ b/ion_phys/tests/test_rates.py
@@ -33,7 +33,8 @@ class TestTSS(unittest.TestCase):
             trans = rates.get_transitions(Lasers)
 
             spont = rates.get_spont()
-            r = spont[p_idx, p_idx] / (trans[p_idx, p_idx]+trans[p_idx, s_idx])
+            r = spont[p_idx,
+                      p_idx] / (trans[p_idx, p_idx] + trans[p_idx, s_idx])
             self.assertAlmostEqual(r, 1., places=7)
 
     def test_steady_state_intensity(self):
@@ -55,12 +56,12 @@ class TestTSS(unittest.TestCase):
 
             Np_ss = _steady_state_population(I)
             # transition rates normalised by A coefficient
-            dNp_dt = (trans[p_idx, p_idx] * Np_ss
-                      + trans[p_idx, s_idx] * (1 - Np_ss))
+            dNp_dt = (trans[p_idx, p_idx] * Np_ss + trans[p_idx, s_idx] *
+                      (1 - Np_ss))
             dNp_dt = dNp_dt / (trans[p_idx, p_idx] + trans[p_idx, s_idx])
             self.assertAlmostEqual(0., dNp_dt, places=7)
-            dNs_dt = (trans[s_idx, p_idx] * Np_ss
-                      + trans[s_idx, s_idx] * (1 - Np_ss))
+            dNs_dt = (trans[s_idx, p_idx] * Np_ss + trans[s_idx, s_idx] *
+                      (1 - Np_ss))
             dNs_dt = dNs_dt / (trans[s_idx, p_idx] + trans[s_idx, s_idx])
             self.assertAlmostEqual(0., dNs_dt, places=7)
 
@@ -82,19 +83,19 @@ class TestTSS(unittest.TestCase):
         # detuning scan relative to linewidth
         norm_detuning = [-1e4, 2.3e1, 2, -4, 0.5, 0]
         for det in norm_detuning:
-            I_eff = 1/(4 * det**2 + 1)
+            I_eff = 1 / (4 * det**2 + 1)
             Np_ss = _steady_state_population(I_eff)
 
-            Lasers = [Laser("393", q=+1, I=1., delta=delta + line_width*det)]
+            Lasers = [Laser("393", q=+1, I=1., delta=delta + line_width * det)]
             trans = rates.get_transitions(Lasers)
 
             # transition rates normalised by A coefficient
-            dNp_dt = (trans[p_idx, p_idx] * Np_ss
-                      + trans[p_idx, s_idx] * (1 - Np_ss))
+            dNp_dt = (trans[p_idx, p_idx] * Np_ss + trans[p_idx, s_idx] *
+                      (1 - Np_ss))
             dNp_dt = dNp_dt / (trans[p_idx, p_idx] + trans[p_idx, s_idx])
             self.assertAlmostEqual(0., dNp_dt, places=7)
-            dNs_dt = (trans[s_idx, p_idx] * Np_ss
-                      + trans[s_idx, s_idx] * (1 - Np_ss))
+            dNs_dt = (trans[s_idx, p_idx] * Np_ss + trans[s_idx, s_idx] *
+                      (1 - Np_ss))
             dNs_dt = dNs_dt / (trans[s_idx, p_idx] + trans[s_idx, s_idx])
             self.assertAlmostEqual(0., dNs_dt, places=7)
 

--- a/ion_phys/tests/test_spont.py
+++ b/ion_phys/tests/test_spont.py
@@ -12,7 +12,7 @@ class TestGamma(unittest.TestCase):
         ion.calc_Epole()
         Gamma_ion = ion.Gamma
         I = ion.I
-        Idim = int(np.rint(2*I+1))
+        Idim = int(np.rint(2 * I + 1))
         Gamma = np.zeros((ion.num_states, ion.num_states))
 
         for name, transition in ion.transitions.items():
@@ -21,18 +21,18 @@ class TestGamma(unittest.TestCase):
             upper = transition.upper
             Ju = upper.J
             Jl = lower.J
-            Jdim_l = int(np.rint(2*Jl+1))
-            l_dim = Idim*Jdim_l
+            Jdim_l = int(np.rint(2 * Jl + 1))
+            l_dim = Idim * Jdim_l
 
-            dJ = Ju-Jl
+            dJ = Ju - Jl
             dL = upper.L - lower.L
             if dJ in [-1, 0, +1] and dL in [-1, 0, +1]:
                 order = 1
             elif abs(dJ) in [0, 1, 2] and abs(dL) in [0, 1, 2]:
                 order = 2
             else:
-                raise ValueError("Unsupported transition order {}"
-                                 .format(order))
+                raise ValueError(
+                    "Unsupported transition order {}".format(order))
 
             subspace = np.r_[ion.slice(lower), ion.slice(upper)]
 
@@ -43,20 +43,18 @@ class TestGamma(unittest.TestCase):
                     Ml = ion.M[l_ind]
                     Mu = ion.M[u_ind]
                     q = Mu - Ml
-                    if q not in range(-order, order+1):
+                    if q not in range(-order, order + 1):
                         continue
 
-                    Gamma[l_ind, u_ind] = A*(
-                        (2*Ju+1)
-                        * (2*Fl+1)
-                        * (2*Fu+1)
-                        * (wigner_3j(Fu, order, Fl, -Mu, q, Ml))**2
-                        * (wigner_6j(Ju, I, Fu, Fl, order, Jl)**2))
+                    Gamma[l_ind, u_ind] = A * (
+                        (2 * Ju + 1) * (2 * Fl + 1) * (2 * Fu + 1) *
+                        (wigner_3j(Fu, order, Fl, -Mu, q, Ml))**2 *
+                        (wigner_6j(Ju, I, Fu, Fl, order, Jl)**2))
 
             subspace = np.ix_(subspace, subspace)
             scale = np.max(np.max(np.abs(Gamma[subspace])))
-            eps = np.max(np.max(np.abs(Gamma[subspace]-Gamma_ion[subspace])))
-            self.assertTrue(eps/scale < 1e-4)
+            eps = np.max(np.max(np.abs(Gamma[subspace] - Gamma_ion[subspace])))
+            self.assertTrue(eps / scale < 1e-4)
 
     def test_HF(self):
         """ Check that, in the high-field, our scattering rates match a more
@@ -64,7 +62,7 @@ class TestGamma(unittest.TestCase):
         ion = Ca43(B=1000)
         ion.calc_Epole()
         Gamma_ion = ion.Gamma
-        Idim = int(np.rint(2*ion.I+1))
+        Idim = int(np.rint(2 * ion.I + 1))
         Gamma = np.zeros((ion.num_states, ion.num_states))
 
         for _, transition in ion.transitions.items():
@@ -73,18 +71,18 @@ class TestGamma(unittest.TestCase):
             upper = transition.upper
             Ju = upper.J
             Jl = lower.J
-            Jdim_l = int(np.rint(2*Jl+1))
-            l_dim = Idim*Jdim_l
+            Jdim_l = int(np.rint(2 * Jl + 1))
+            l_dim = Idim * Jdim_l
 
-            dJ = Ju-Jl
+            dJ = Ju - Jl
             dL = upper.L - lower.L
             if dJ in [-1, 0, +1] and dL in [-1, 0, +1]:
                 order = 1
             elif abs(dJ) in [0, 1, 2] and abs(dL) in [0, 1, 2]:
                 order = 2
             else:
-                raise ValueError("Unsupported transition order {}"
-                                 .format(order))
+                raise ValueError(
+                    "Unsupported transition order {}".format(order))
 
             subspace = np.r_[ion.slice(lower), ion.slice(upper)]
 
@@ -95,15 +93,15 @@ class TestGamma(unittest.TestCase):
                     M_l = ion.MJ[l_ind]
                     M_u = ion.MJ[u_ind]
                     q = M_u - M_l
-                    if q not in range(-order, order+1):
+                    if q not in range(-order, order + 1):
                         continue
-                    Gamma[l_ind, u_ind] = A*(2*Ju+1)*(
-                        wigner_3j(Ju, order, Jl, -M_u, q, M_l))**2
+                    Gamma[l_ind, u_ind] = A * (2 * Ju + 1) * (wigner_3j(
+                        Ju, order, Jl, -M_u, q, M_l))**2
 
             subspace = np.ix_(subspace, subspace)
             scale = np.max(np.max(np.abs(Gamma[subspace])))
-            eps = np.max(np.max(np.abs(Gamma[subspace]-Gamma_ion[subspace])))
-            self.assertTrue(eps/scale < 1e-4)
+            eps = np.max(np.max(np.abs(Gamma[subspace] - Gamma_ion[subspace])))
+            self.assertTrue(eps / scale < 1e-4)
 
 
 if __name__ == '__main__':

--- a/ion_phys/tests/test_stim.py
+++ b/ion_phys/tests/test_stim.py
@@ -9,16 +9,18 @@ class TestStim(unittest.TestCase):
         """Test with lasers on multiple transitions (see #15)"""
         ion = Ca43(B=146e-4)
         rates = Rates(ion)
-        Lasers = [Laser("397", q=0, I=1, delta=0),
-                  Laser("866", q=0, I=1, delta=0),
-                  ]
+        Lasers = [
+            Laser("397", q=0, I=1, delta=0),
+            Laser("866", q=0, I=1, delta=0),
+        ]
         rates.get_transitions(Lasers)
 
     def test_multi_laser(self):
         """Test with multiple lasers on one transition"""
         ion = Ca43(B=146e-4)
         rates = Rates(ion)
-        Lasers = [Laser("397", q=0, I=1, delta=0),
-                  Laser("397", q=+1, I=1, delta=0),
-                  ]
+        Lasers = [
+            Laser("397", q=0, I=1, delta=0),
+            Laser("397", q=+1, I=1, delta=0),
+        ]
         rates.get_transitions(Lasers)

--- a/ion_phys/tests/test_wigner.py
+++ b/ion_phys/tests/test_wigner.py
@@ -13,9 +13,9 @@ class TestWigner(unittest.TestCase):
         for j1 in j:
             for j2 in j:
                 for j3 in j:
-                    for m1 in np.arange(-j1, j1+1):
-                        for m2 in np.arange(-j2, j2+1):
-                            for m3 in np.arange(-j3, j3+1):
+                    for m1 in np.arange(-j1, j1 + 1):
+                        for m2 in np.arange(-j2, j2 + 1):
+                            for m3 in np.arange(-j3, j3 + 1):
                                 ip = wigner3j(j1, j2, j3, m1, m2, m3)
                                 sp = wigner.wigner_3j(j1, j2, j3, m1, m2, m3)
                                 self.assertTrue(np.abs(ip - sp) < 1e-15)

--- a/ion_phys/utils.py
+++ b/ion_phys/utils.py
@@ -36,9 +36,9 @@ def df_dB(ion, lower, upper, eps=1e-6):
     """
     f = ion.delta(lower, upper)
     ion = deepcopy(ion)
-    ion.setB(ion.B+eps)
+    ion.setB(ion.B + eps)
     fpr = ion.delta(lower, upper)
-    return (fpr - f)/eps
+    return (fpr - f) / eps
 
 
 def d2f_dB2(ion, lower, upper, eps=1e-4):
@@ -56,10 +56,10 @@ def d2f_dB2(ion, lower, upper, eps=1e-4):
     """
     df = df_dB(ion, lower, upper)
     ion = deepcopy(ion)
-    ion.setB(ion.B+eps)
+    ion.setB(ion.B + eps)
     dfpr = df_dB(ion, lower, upper)
 
-    return (dfpr - df)/eps
+    return (dfpr - df) / eps
 
 
 def field_insensitive_point(ion, lower, upper, B_min=1e-3, B_max=1e-1):
@@ -104,7 +104,7 @@ def ac_zeeman_shift(ion, state, f_RF):
     E = ion.E[states]
     M = ion.M[states]
     R = ion.M1[states]
-    rabi = R/consts.hbar
+    rabi = R / consts.hbar
 
     acz = np.zeros(3)
     for q in [-1, 0, +1]:
@@ -112,5 +112,5 @@ def ac_zeeman_shift(ion, state, f_RF):
         for _state in np.argwhere(Mpr == Mpr):
             freq = E[_state] - E[state]
             w = rabi[state, _state][0]
-            acz[q + 1] += 0.5*w**2*(freq/(freq**2 - (f_RF)**2))
+            acz[q + 1] += 0.5 * w**2 * (freq / (freq**2 - (f_RF)**2))
     return acz

--- a/ion_phys/wigner.py
+++ b/ion_phys/wigner.py
@@ -7,10 +7,10 @@ from functools import lru_cache
 # warnings.filterwarnings('error')
 
 _max_fact = 12  # 12 for int32, 20 for int64
-_fact_store = np.ones(_max_fact+1, dtype=np.int32)
+_fact_store = np.ones(_max_fact + 1, dtype=np.int32)
 
 for n in np.arange(_max_fact, dtype=np.int32):
-    _fact_store[n+1] = _fact_store[n]*np.int32(n+1)
+    _fact_store[n + 1] = _fact_store[n] * np.int32(n + 1)
 
 
 def _fact(n):
@@ -23,14 +23,14 @@ def wigner3j(j1, j2, j3, m1, m2, m3):
     """ Returns the Wigner 3J symbol. """
 
     # selection rules
-    jT = np.int32(j1+j2+j3)
+    jT = np.int32(j1 + j2 + j3)
     if m1 + m2 + m3 != 0:
         return 0
     if abs(m1) > j1 or abs(m2) > j2 or abs(m3) > j3:
         return 0
-    if j3 < np.abs(j1-j2) or j3 > j1 + j2:
+    if j3 < np.abs(j1 - j2) or j3 > j1 + j2:
         return 0
-    if jT != j1+j2+j3:
+    if jT != j1 + j2 + j3:
         return 0
     if not any([m1, m2]) and jT % 2 != 0:
         return 0
@@ -52,28 +52,28 @@ def wigner3j(j1, j2, j3, m1, m2, m3):
         m2 = -m2
         m3 = -m3
         sign += 1
-    sign = (-1)**(jT*sign)
+    sign = (-1)**(jT * sign)
     return sign * _wigner3j(j1, j2, j3, m1, m2, m3)
 
 
 @lru_cache(maxsize=512)
 def _wigner3j(j1, j2, j3, m1, m2, m3):
-    sign = (-1)**(np.abs(j1-j2-m3))
+    sign = (-1)**(np.abs(j1 - j2 - m3))
     tri = np.sqrt(
-        (_fact(j1+j2-j3)*_fact(j1+j3-j2)*_fact(j2+j3-j1))/_fact(j1+j2+j3+1))
-    pre = np.sqrt(np.prod([_fact(j+m) * _fact(j-m) for (j, m) in [(j1, m1),
-                                                                  (j2, m2),
-                                                                  (j3, m3)]]))
+        (_fact(j1 + j2 - j3) * _fact(j1 + j3 - j2) * _fact(j2 + j3 - j1)) /
+        _fact(j1 + j2 + j3 + 1))
+    pre = np.sqrt(
+        np.prod([
+            _fact(j + m) * _fact(j - m)
+            for (j, m) in [(j1, m1), (j2, m2), (j3, m3)]
+        ]))
 
-    kmax = int(np.rint(min([j1+j2-j3, j1-m1, j2+m2])))
-    kmin = int(np.rint(max([-(j3-j2+m1), -(j3-j1-m2), 0])))
+    kmax = int(np.rint(min([j1 + j2 - j3, j1 - m1, j2 + m2])))
+    kmin = int(np.rint(max([-(j3 - j2 + m1), -(j3 - j1 - m2), 0])))
 
     fact = 0
-    for k in range(kmin, kmax+1):
-        fact += (-1)**k / (_fact(k)
-                           * _fact(j1+j2-j3-k)
-                           * _fact(j1-m1-k)
-                           * _fact(j2+m2-k)
-                           * _fact(j3-j2+m1+k)
-                           * _fact(j3-j1-m2+k))
-    return sign*tri*pre*fact
+    for k in range(kmin, kmax + 1):
+        fact += (-1)**k / (_fact(k) * _fact(j1 + j2 - j3 - k) *
+                           _fact(j1 - m1 - k) * _fact(j2 + m2 - k) *
+                           _fact(j3 - j2 + m1 + k) * _fact(j3 - j1 - m2 + k))
+    return sign * tri * pre * fact


### PR DESCRIPTION
To get the ball rolling, as discussed in #30.

I'm not going to join any bikeshedding regarding the settings – feel free to amend the config and re-do the last commit before merging.

YAPF is what is used for many other projects in the group; I ended up choosing it mainly because Black wasn't compatible with the Python version we had widely deployed at the time. So far, it has worked out nicely in oxart, oitg, ndscan, hoa2-common, etc. Doesn't handle Migen very well, but none of the formatters do (I can't wait for nmigen with its context-manager-based syntax).

I settled on a line length of 88 for the other projects based on what worked best for the existing code (also the default for Black), but didn't include this here, as everything seemed to conform to flake8's default 79 character limit. (Even with my default two-window side-by-side editor layout on my Mac, the editors aren't that narrow, so that might be a relic of the past.)

The PR includes fixes for a few formatting oddities I noticed while scrolling through the YAPF-generated diff as well.