### PR TITLE
atomic_physics/common: allow for state index=0 in level()

### DIFF
--- a/atomic_physics/common.py
+++ b/atomic_physics/common.py
@@ -219,7 +219,7 @@ class Atom:
         for level, data in self.levels.items():
             sl = data.slice()
             # kludge: pending redesign of LevelData (see #38)
-            if state > min(sl.start, sl.stop) and state < max(sl.start, sl.stop):
+            if state >= min(sl.start, sl.stop) and state < max(sl.start, sl.stop):
                 return level
         raise ValueError("No state with index {}".format(state))
 

--- a/atomic_physics/tests/test_level.py
+++ b/atomic_physics/tests/test_level.py
@@ -1,0 +1,22 @@
+"""Test Spin 1/2 nuclei"""
+import unittest
+from atomic_physics.ions import ca40
+
+
+class TesLevel(unittest.TestCase):
+    """
+    Test level assignment
+    """
+
+    def test_level(self):
+        ion = ca40.Ca40(B=100e-4, level_filter=[ca40.ground_level, ca40.shelf])
+
+        # check that states with indices 0 and 1 belong to S1/2
+        for i in range(2):
+            self.assertEqual(ion.level(i).L, 0)
+            self.assertEqual(ion.level(i).J, 0.5)
+
+        # check that states with indices 2-7 belong to D5/2
+        for i in range(6):
+            self.assertEqual(ion.level(i + 2).L, 2)
+            self.assertEqual(ion.level(i + 2).J, 2.5)


### PR DESCRIPTION
Currently calling `atom.level(state=0)` results in `ValueError: No state with index 0`.
I believe [97a1514](https://github.com/OxfordIonTrapGroup/atomic_physics/commit/97a1514be357e33430cb7601884e90e2657f7c34) fixes this.

The following code was used to test:
```
from atomic_physics.ions import ca40

if __name__=="__main__":
    ion = ca40.Ca40(B=10e-4)
    print("State index 1: ", ion.level(1))
    print("State index 0: ", ion.level(0))
```

Output at [b32491c](https://github.com/OxfordIonTrapGroup/atomic_physics/commit/b32491c9877e9c758a4613207005e822de82f393):
```
State index 1:  Level(n=4, L=0, J=0.5, S=0.5)
Traceback (most recent call last):
  File "/Users/ana/scratch/misc/state_idx_0_test.py", line 6, in <module>
    print("State index 0: ", ion.level(0))
  File "/Users/ana/scratch/atomic_physics/atomic_physics/common.py", line 224, in level
    raise ValueError("No state with index {}".format(state))
ValueError: No state with index 0
```

Output at [97a1514](https://github.com/OxfordIonTrapGroup/atomic_physics/commit/97a1514be357e33430cb7601884e90e2657f7c34):
```
State index 1:  Level(n=4, L=0, J=0.5, S=0.5)
State index 0:  Level(n=4, L=0, J=0.5, S=0.5)
```