### PR TITLE
Barium data

### DIFF
--- a/atomic_physics/common.py
+++ b/atomic_physics/common.py
@@ -363,7 +363,7 @@ class Atom:
                 H += -gI * _uN * B * Iz
                 H += data.Ahfs * IdotJ
 
-                if J > 1 / 2:
+                if J > 1 / 2 and I > 1 / 2:
                     IdotJ2 = np.linalg.matrix_power(IdotJ, 2)
                     ident = np.identity(I_dim * J_dim)
                     H += (

--- a/atomic_physics/common.py
+++ b/atomic_physics/common.py
@@ -219,7 +219,7 @@ class Atom:
         for level, data in self.levels.items():
             sl = data.slice()
             # kludge: pending redesign of LevelData (see #38)
-            if state > min(sl.start, sl.stop) and state < max(sl.start, sl.stop):
+            if state >= min(sl.start, sl.stop) and state < max(sl.start, sl.stop):
                 return level
         raise ValueError("No state with index {}".format(state))
 

--- a/atomic_physics/common.py
+++ b/atomic_physics/common.py
@@ -406,7 +406,7 @@ class Atom:
 
             for M in set(self.M[lev]):
                 for Fidx, idx in np.ndenumerate(np.where(M == self.M[lev])):
-                    self.F[lev][idx] = F_list[M <= F_list][Fidx[1]]
+                    self.F[lev][idx] = F_list[abs(M) <= F_list][Fidx[1]]
 
         if self.M1 is not None:
             self.calc_M1()

--- a/atomic_physics/common.py
+++ b/atomic_physics/common.py
@@ -219,7 +219,7 @@ class Atom:
         for level, data in self.levels.items():
             sl = data.slice()
             # kludge: pending redesign of LevelData (see #38)
-            if state >= min(sl.start, sl.stop) and state < max(sl.start, sl.stop):
+            if state > min(sl.start, sl.stop) and state < max(sl.start, sl.stop):
                 return level
         raise ValueError("No state with index {}".format(state))
 
@@ -363,7 +363,7 @@ class Atom:
                 H += -gI * _uN * B * Iz
                 H += data.Ahfs * IdotJ
 
-                if J > 1 / 2 and I > 1 / 2:
+                if J > 1 / 2:
                     IdotJ2 = np.linalg.matrix_power(IdotJ, 2)
                     ident = np.identity(I_dim * J_dim)
                     H += (

--- a/atomic_physics/ions/ba133.py
+++ b/atomic_physics/ions/ba133.py
@@ -60,7 +60,7 @@ class Ba133(ap.Atom):
             D32: ap.LevelData(
                 Ahfs=-47.3e6 * consts.h,  # [4]
                 Bhfs=-3.7 * consts.h,  # [4]
-                g_I=(2 / 1) *0.77167,  # [3]
+                g_I=(2 / 1) * 0.77167,  # [3]
             ),
             D52: ap.LevelData(
                 Ahfs=-89.59e6 * consts.h / 3,  # [5]

--- a/atomic_physics/ions/ba133.py
+++ b/atomic_physics/ions/ba133.py
@@ -1,0 +1,122 @@
+""" 133Ba+
+
+ToDo: We need a reference for the Einstein A values
+A cursory look turned up:
+    Kramida, A., et al., NIST Atomic Spectra Database (ver. 5.8), [Online].
+However, this data is based of calculations done in the late 60s. These are
+only ~10% accurate.
+
+References:
+[1] - F. Arbes, et al., Zeitschrift fur Physik D: Atoms, Molecules and
+  Clusters, 31, 27 (1994)
+[2] - G. Tommaseo, et al., The European Physical Journal D, 25 (2003)
+[3] - T. P. Harty, et al. Phys. Rev. Lett 113, 220501 (2014)
+[4] - W.  Nortershauser, et al., The European Physical Journal D, 2 (1998)
+[5] - J. Benhelm, et al., PHYSICAL REVIEW A 75, 032506 (2007)
+[6] - A. Kramida, At. Data Nucl. Data Tables 133-134, 101322 (2020)
+"""
+import numpy as np
+import typing
+import scipy.constants as consts
+import atomic_physics as ap
+
+
+# level aliases
+ground_level = S12 = ap.Level(n=4, S=1 / 2, L=0, J=1 / 2)
+P12 = ap.Level(n=4, S=1 / 2, L=1, J=1 / 2)
+P32 = ap.Level(n=4, S=1 / 2, L=1, J=3 / 2)
+D32 = ap.Level(n=4, S=1 / 2, L=2, J=3 / 2)
+shelf = D52 = ap.Level(n=4, S=1 / 2, L=2, J=5 / 2)
+
+
+class Ba133(ap.Atom):
+    def __init__(
+        self,
+        *,
+        B: typing.Optional[float] = None,
+        level_filter: typing.Optional[typing.List[ap.Level]] = None
+    ):
+        """43Ca+ atomic structure.
+
+        :param B: B-field in Tesla (can be changed using :meth setB:)
+        :param level_filter: list of Levels to include in the simulation, if
+            None we include all levels.
+        """
+        levels = {
+            ground_level: ap.LevelData(
+                g_J=2.00225664,  # [2]
+                g_I=(2 / 1) * 0.77167,  # [3]
+                Ahfs=-3225.60828640e6 * consts.h / 4,  # [1]
+            ),
+            P12: ap.LevelData(
+                Ahfs=-145.4e6 * consts.h,
+                g_I=(2 / 1) * 0.77167,  # [4]  # [3]
+            ),
+            P32: ap.LevelData(
+                Ahfs=-31.4e6 * consts.h,  # [4]
+                Bhfs=-6.9 * consts.h,  # [4]
+                g_I=(2 / 1) * 0.77167,  # [3]
+            ),
+            D32: ap.LevelData(
+                Ahfs=-47.3e6 * consts.h,  # [4]
+                Bhfs=-3.7 * consts.h,  # [4]
+                g_I=(2 / 1) *0.77167,  # [3]
+            ),
+            D52: ap.LevelData(
+                Ahfs=-89.59e6 * consts.h * consts.h,  # [5]
+                g_I=(2 / 1) * 0.77167,  # [3]
+            ),
+        }
+
+        transitions = {
+            "397": ap.Transition(
+                lower=S12,
+                upper=P12,
+                A=132e6,  # [?]
+                freq=2 * np.pi * 755223443.81e6,  # [6]
+            ),
+            "393": ap.Transition(
+                lower=S12,
+                upper=P32,
+                A=135e6,  # [?]
+                freq=2 * np.pi * 761905691.40e6,  # [6]
+            ),
+            "866": ap.Transition(
+                lower=D32,
+                upper=P12,
+                A=8.4e6,  # [?]
+                freq=2 * np.pi * 345996772.78e6,  # [6]
+            ),
+            "850": ap.Transition(
+                lower=D32,
+                upper=P32,
+                A=0.955e6,  # [?]
+                freq=2 * np.pi * 352679020.37e6,  # [6]
+            ),
+            "854": ap.Transition(
+                lower=D52,
+                upper=P32,
+                A=8.48e6,  # [?]
+                freq=2 * np.pi * 350859426.91e6,  # [6]
+            ),
+            "729": ap.Transition(
+                lower=S12,
+                upper=D52,
+                A=0.856,  # [?]
+                freq=411046264.4881 * 2 * np.pi,  # [6]
+            ),
+            "733": ap.Transition(
+                lower=S12,
+                upper=D32,
+                A=0.850,  # [?]
+                freq=409226671.03 * 2 * np.pi,  # [6]
+            ),
+        }
+
+        super().__init__(
+            B=B,
+            I=1 / 2,
+            levels=levels,
+            transitions=transitions,
+            level_filter=level_filter,
+        )

--- a/atomic_physics/ions/ba133.py
+++ b/atomic_physics/ions/ba133.py
@@ -8,7 +8,7 @@ only ~10% accurate.
 
 The transition frequencies are calculated based on the 138Ba+ frequencies
 from [1] and the isotope shifts in the second reference listed next to
-the freqiency. Where no references are given, the transition frequencies
+the frequency. Where no references are given, the transition frequencies
 were calculated based on transition frequencies between other levels.
 For example the frequency of the 1762 nm transition f(1762) was found
 from f(1762)=f(455)-f(614).

--- a/atomic_physics/ions/ba133.py
+++ b/atomic_physics/ions/ba133.py
@@ -6,6 +6,13 @@ A cursory look turned up:
 However, this data is based of calculations done in the late 60s. These are
 only ~10% accurate.
 
+The transition frequencies are calculated based on the 138Ba+ frequencies
+from [1] and the isotope shifts in the second reference listed next to
+the freqiency. Where no references are given, the transition frequencies
+were calculated based on transition frequencies between other levels.
+For example the frequency of the 1762 nm transition f(1762) was found
+from f(1762)=f(455)-f(614).
+
 References:
 [1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
 [2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621, (1990)
@@ -76,43 +83,43 @@ class Ba133(ap.Atom):
                 lower=S12,
                 upper=P12,
                 A=9.53e7,  # [1]
-                freq=2 * np.pi * 607426317510693.9,  #
+                freq=2 * np.pi * 607426317511066.9,  # [1], [6]
             ),
             "455": ap.Transition(
                 lower=S12,
                 upper=P32,
                 A=1.11e8,  # [1]
-                freq=2 * np.pi * 658116515416903.1,  #
+                freq=2 * np.pi * 658116515417261.1,  # [1], [7]
             ),
             "650": ap.Transition(
                 lower=D32,
                 upper=P12,
                 A=3.1e7,  # [1]
-                freq=2 * np.pi * 461311910409872.25,  #
+                freq=2 * np.pi * 461311910410070.25,  # [1], [6]
             ),
             "585": ap.Transition(
                 lower=D32,
                 upper=P32,
                 A=6.0e6,  # [1]
-                freq=2 * np.pi * 512002108316081.56,  #
+                freq=2 * np.pi * 512002108316264.5,
             ),
             "614": ap.Transition(
                 lower=D52,
                 upper=P32,
                 A=4.12e7,  # [1]
-                freq=2 * np.pi * 487990081496342.56,  #
+                freq=2 * np.pi * 487990081496558.56,  # [1], [7]
             ),
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
                 A=29e-3,  # [2]
-                freq=2 * np.pi * 170126433920560.6,  #
+                freq=2 * np.pi * 170126433920702.56,
             ),
             "2051": ap.Transition(
                 lower=S12,
                 upper=D32,
                 A=12.5e-3,  # [3]
-                freq=2 * np.pi * 146114407100821.6,  #
+                freq=2 * np.pi * 146114407100996.62,
             ),
         }
 

--- a/atomic_physics/ions/ba133.py
+++ b/atomic_physics/ions/ba133.py
@@ -46,7 +46,7 @@ class Ba133(ap.Atom):
             ground_level: ap.LevelData(
                 g_J=2.00225664,  # [2]
                 g_I=(2 / 1) * 0.77167,  # [3]
-                Ahfs=-3225.60828640e6 * consts.h / 4,  # [1]
+                Ahfs=-9925.45355459e6 * consts.h,  # [1]
             ),
             P12: ap.LevelData(
                 Ahfs=-145.4e6 * consts.h,
@@ -63,7 +63,7 @@ class Ba133(ap.Atom):
                 g_I=(2 / 1) *0.77167,  # [3]
             ),
             D52: ap.LevelData(
-                Ahfs=-89.59e6 * consts.h * consts.h,  # [5]
+                Ahfs=-89.59e6 * consts.h / 3,  # [5]
                 g_I=(2 / 1) * 0.77167,  # [3]
             ),
         }

--- a/atomic_physics/ions/ba133.py
+++ b/atomic_physics/ions/ba133.py
@@ -7,13 +7,18 @@ However, this data is based of calculations done in the late 60s. These are
 only ~10% accurate.
 
 References:
-[1] - F. Arbes, et al., Zeitschrift fur Physik D: Atoms, Molecules and
-  Clusters, 31, 27 (1994)
-[2] - G. Tommaseo, et al., The European Physical Journal D, 25 (2003)
-[3] - T. P. Harty, et al. Phys. Rev. Lett 113, 220501 (2014)
-[4] - W.  Nortershauser, et al., The European Physical Journal D, 2 (1998)
-[5] - J. Benhelm, et al., PHYSICAL REVIEW A 75, 032506 (2007)
-[6] - A. Kramida, At. Data Nucl. Data Tables 133-134, 101322 (2020)
+[1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
+[2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621, (1990)
+[3] - N. Yu, W. Nagourney, and H. Dehmelt, Phys. Rev. Lett. 78, 4898 (1997)
+[4] - N. J. Stone, Table of nuclear magnetic dipole and electric
+  quadrupole moments, Atomic Data and Nuclear Data Tables, Volume 90,
+  Issue 1 (2005)
+[5] - H. Knab, K. H. Knöll, F. Scheerer and G. Werth, Zeitschrift für
+  Physik D Atoms, Molecules and Clusters volume 25, pages205–208 (1993)
+[6] - David Hucul, Justin E. Christensen, Eric R. Hudson, and
+  Wesley C. Campbell, Phys. Rev. Lett. 119, 100501 (2017)
+[7] - J.E. Christensen, D. Hucul, W.C. Campbell et al.,
+  npj Quantum Inf 6, 35 (2020).
 """
 import numpy as np
 import typing
@@ -36,7 +41,7 @@ class Ba133(ap.Atom):
         B: typing.Optional[float] = None,
         level_filter: typing.Optional[typing.List[ap.Level]] = None
     ):
-        """43Ca+ atomic structure.
+        """133Ba+ atomic structure.
 
         :param B: B-field in Tesla (can be changed using :meth setB:)
         :param level_filter: list of Levels to include in the simulation, if
@@ -44,72 +49,70 @@ class Ba133(ap.Atom):
         """
         levels = {
             ground_level: ap.LevelData(
-                g_J=2.00225664,  # [2]
-                g_I=(2 / 1) * 0.77167,  # [3]
-                Ahfs=-9925.45355459e6 * consts.h,  # [1]
+                Ahfs=-9925.45355459e6 * consts.h,  # [6]
+                g_J=2.0024906,  # [5]
+                g_I=(2 / 1) * -0.77167,  # [4]
             ),
             P12: ap.LevelData(
-                Ahfs=-145.4e6 * consts.h,
-                g_I=(2 / 1) * 0.77167,  # [4]  # [3]
+                Ahfs=-1840e6 * consts.h,  # [6]
+                g_I=(2 / 1) * -0.77167,  # [4]
             ),
             P32: ap.LevelData(
-                Ahfs=-31.4e6 * consts.h,  # [4]
-                Bhfs=-6.9 * consts.h,  # [4]
-                g_I=(2 / 1) * 0.77167,  # [3]
+                Ahfs=-311.5e6 * consts.h,  # [8]
+                g_I=(2 / 1) * -0.77167,  # [4]
             ),
             D32: ap.LevelData(
-                Ahfs=-47.3e6 * consts.h,  # [4]
-                Bhfs=-3.7 * consts.h,  # [4]
-                g_I=(2 / 1) * 0.77167,  # [3]
+                Ahfs=-468.5e6 * consts.h,  # [6]
+                g_I=(2 / 1) * -0.77167,  # [4]
             ),
             D52: ap.LevelData(
-                Ahfs=-89.59e6 * consts.h / 3,  # [5]
-                g_I=(2 / 1) * 0.77167,  # [3]
+                Ahfs=16.6e6 * consts.h / 3,  # [8]
+                g_I=(2 / 1) * -0.77167,  # [4]
             ),
         }
 
         transitions = {
-            "397": ap.Transition(
+            "493": ap.Transition(
                 lower=S12,
                 upper=P12,
-                A=132e6,  # [?]
-                freq=2 * np.pi * 755223443.81e6,  # [6]
+                A=9.53e7,  # [1]
+                freq=2 * np.pi * 607426317510693.9,  #
             ),
-            "393": ap.Transition(
+            "455": ap.Transition(
                 lower=S12,
                 upper=P32,
-                A=135e6,  # [?]
-                freq=2 * np.pi * 761905691.40e6,  # [6]
+                A=1.11e8,  # [1]
+                freq=2 * np.pi * 658116515416903.1,  #
             ),
-            "866": ap.Transition(
+            "650": ap.Transition(
                 lower=D32,
                 upper=P12,
-                A=8.4e6,  # [?]
-                freq=2 * np.pi * 345996772.78e6,  # [6]
+                A=3.1e7,  # [1]
+                freq=2 * np.pi * 461311910409872.25,  #
             ),
-            "850": ap.Transition(
+            "585": ap.Transition(
                 lower=D32,
                 upper=P32,
-                A=0.955e6,  # [?]
-                freq=2 * np.pi * 352679020.37e6,  # [6]
+                A=6.0e6,  # [1]
+                freq=2 * np.pi * 512002108316081.56,  #
             ),
-            "854": ap.Transition(
+            "614": ap.Transition(
                 lower=D52,
                 upper=P32,
-                A=8.48e6,  # [?]
-                freq=2 * np.pi * 350859426.91e6,  # [6]
+                A=4.12e7,  # [1]
+                freq=2 * np.pi * 487990081496342.56,  #
             ),
-            "729": ap.Transition(
+            "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=0.856,  # [?]
-                freq=411046264.4881 * 2 * np.pi,  # [6]
+                A=29e-3,  # [2]
+                freq=2 * np.pi * 170126433920560.6,  #
             ),
-            "733": ap.Transition(
+            "2051": ap.Transition(
                 lower=S12,
                 upper=D32,
-                A=0.850,  # [?]
-                freq=409226671.03 * 2 * np.pi,  # [6]
+                A=12.5e-3,  # [3]
+                freq=2 * np.pi * 146114407100821.6,  #
             ),
         }
 

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -48,7 +48,7 @@ class Ba135(ap.Atom):
             ground_level: ap.LevelData(
                 g_J=2.00225664,  # [2]
                 g_I=(2 / 3) * 0.838627,  # [3]
-                Ahfs=-3225.60828640e6 * consts.h / 4,  # [1]
+                Ahfs=-3225.60828640e6 * consts.h,  # [1]
             ),
             P12: ap.LevelData(
                 Ahfs=-145.4e6 * consts.h,

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -72,54 +72,47 @@ class Ba135(ap.Atom):
         }
 
         transitions = {
-            "493":
-            ap.Transition(
+            "493": ap.Transition(
                 lower=S12,
                 upper=P12,
                 A=9.53e7,  # [1]
-                freq=2 * np.pi * 607426317510693.9  # [1]
+                freq=2 * np.pi * 607426317510693.9,  # [1]
             ),
-            "455":
-            ap.Transition(
+            "455": ap.Transition(
                 lower=S12,
                 upper=P32,
                 A=1.11e8,  # [1]
-                freq=2 * np.pi * 658116515416903.1  # [1]
+                freq=2 * np.pi * 658116515416903.1,  # [1]
             ),
-            "650":
-            ap.Transition(
+            "650": ap.Transition(
                 lower=D32,
                 upper=P12,
                 A=3.1e7,  # [1]
-                freq=2 * np.pi * 461311910409872.25  # [1]
+                freq=2 * np.pi * 461311910409872.25,  # [1]
             ),
-            "585":
-            ap.Transition(
+            "585": ap.Transition(
                 lower=D32,
                 upper=P32,
                 A=6.0e6,  # [1]
-                freq=2 * np.pi * 512002108316081.56  # [1]
+                freq=2 * np.pi * 512002108316081.56,  # [1]
             ),
-            "614":
-            ap.Transition(
+            "614": ap.Transition(
                 lower=D52,
                 upper=P32,
                 A=4.12e7,  # [1]
-                freq=2 * np.pi * 487990081496342.56  # [1]
+                freq=2 * np.pi * 487990081496342.56,  # [1]
             ),
-            "1762":
-            ap.Transition(
+            "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
                 A=0.04,  # [1]
-                freq=2 * np.pi * 170126433920560.6  # [1]
+                freq=2 * np.pi * 170126433920560.6,  # [1]
             ),
-            "2051":
-            ap.Transition(
+            "2051": ap.Transition(
                 lower=S12,
                 upper=D32,
                 A=0.04,  # [1]
-                freq=2 * np.pi * 146114407100821.6  # [1]
+                freq=2 * np.pi * 146114407100821.6,  # [1]
             ),
         }
 

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -24,11 +24,11 @@ import atomic_physics as ap
 
 
 # level aliases
-ground_level = S12 = ap.Level(n=4, S=1 / 2, L=0, J=1 / 2)
-P12 = ap.Level(n=4, S=1 / 2, L=1, J=1 / 2)
-P32 = ap.Level(n=4, S=1 / 2, L=1, J=3 / 2)
-D32 = ap.Level(n=4, S=1 / 2, L=2, J=3 / 2)
-shelf = D52 = ap.Level(n=4, S=1 / 2, L=2, J=5 / 2)
+ground_level = S12 = ap.Level(n=6, S=1 / 2, L=0, J=1 / 2)
+P12 = ap.Level(n=6, S=1 / 2, L=1, J=1 / 2)
+P32 = ap.Level(n=6, S=1 / 2, L=1, J=3 / 2)
+D32 = ap.Level(n=5, S=1 / 2, L=2, J=3 / 2)
+shelf = D52 = ap.Level(n=5, S=1 / 2, L=2, J=5 / 2)
 
 
 class Ba135(ap.Atom):

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -48,7 +48,7 @@ class Ba135(ap.Atom):
             ground_level: ap.LevelData(
                 g_J=2.00225664,  # [2]
                 g_I=(2 / 3) * 0.838627,  # [3]
-                Ahfs=-3225.60828640e6 * consts.h,  # [1]
+                Ahfs=3591.67011718e6 * consts.h,  # [1]
             ),
             P12: ap.LevelData(
                 Ahfs=-145.4e6 * consts.h,

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -1,0 +1,132 @@
+""" 135Ba+
+
+ToDo: We need a reference for the Einstein A values
+A cursory look turned up:
+    Kramida, A., et al., NIST Atomic Spectra Database (ver. 5.8), [Online].
+However, this data is based of calculations done in the late 60s. These are
+only ~10% accurate.
+
+TODO: fix isotope shifts
+
+References:
+[1] - F. Arbes, et al., Zeitschrift fur Physik D: Atoms, Molecules and
+  Clusters, 31, 27 (1994)
+[2] - G. Tommaseo, et al., The European Physical Journal D, 25 (2003)
+[3] - T. P. Harty, et al. Phys. Rev. Lett 113, 220501 (2014)
+[4] - W.  Nortershauser, et al., The European Physical Journal D, 2 (1998)
+[5] - J. Benhelm, et al., PHYSICAL REVIEW A 75, 032506 (2007)
+[6] - A. Kramida, At. Data Nucl. Data Tables 133-134, 101322 (2020)
+"""
+import numpy as np
+import typing
+import scipy.constants as consts
+import atomic_physics as ap
+
+
+# level aliases
+ground_level = S12 = ap.Level(n=4, S=1 / 2, L=0, J=1 / 2)
+P12 = ap.Level(n=4, S=1 / 2, L=1, J=1 / 2)
+P32 = ap.Level(n=4, S=1 / 2, L=1, J=3 / 2)
+D32 = ap.Level(n=4, S=1 / 2, L=2, J=3 / 2)
+shelf = D52 = ap.Level(n=4, S=1 / 2, L=2, J=5 / 2)
+
+
+class Ba135(ap.Atom):
+    def __init__(
+        self,
+        *,
+        B: typing.Optional[float] = None,
+        level_filter: typing.Optional[typing.List[ap.Level]] = None
+    ):
+        """43Ca+ atomic structure.
+
+        :param B: B-field in Tesla (can be changed using :meth setB:)
+        :param level_filter: list of Levels to include in the simulation, if
+            None we include all levels.
+        """
+        levels = {
+            ground_level: ap.LevelData(
+                g_J=2.00225664,  # [2]
+                g_I=(2 / 3) * 0.838627,  # [3]
+                Ahfs=-3225.60828640e6 * consts.h / 4,  # [1]
+            ),
+            P12: ap.LevelData(
+                Ahfs=-145.4e6 * consts.h,
+                g_I=(2 / 3) * 0.838627,  # [4]  # [3]
+            ),
+            P32: ap.LevelData(
+                Ahfs=-31.4e6 * consts.h,  # [4]
+                Bhfs=-6.9 * consts.h,  # [4]
+                g_I=(2 / 3) * 0.838627,  # [3]
+            ),
+            D32: ap.LevelData(
+                Ahfs=-47.3e6 * consts.h,  # [4]
+                Bhfs=-3.7 * consts.h,  # [4]
+                g_I=(2 / 3) * 0.838627,  # [3]
+            ),
+            D52: ap.LevelData(
+                Ahfs=-10.735e6 * consts.h,  # [5]
+                Bhfs=38.688e6 * consts.h,  # [5]
+                g_I=(2 / 3) * 0.838627,  # [3]
+            ),
+        }
+
+        transitions = {
+            "493":
+            ap.Transition(
+                lower=S12,
+                upper=P12,
+                A=9.53e7,  # [1]
+                freq=2 * np.pi * 607426317510693.9  # [1]
+            ),
+            "455":
+            ap.Transition(
+                lower=S12,
+                upper=P32,
+                A=1.11e8,  # [1]
+                freq=2 * np.pi * 658116515416903.1  # [1]
+            ),
+            "650":
+            ap.Transition(
+                lower=D32,
+                upper=P12,
+                A=3.1e7,  # [1]
+                freq=2 * np.pi * 461311910409872.25  # [1]
+            ),
+            "585":
+            ap.Transition(
+                lower=D32,
+                upper=P32,
+                A=6.0e6,  # [1]
+                freq=2 * np.pi * 512002108316081.56  # [1]
+            ),
+            "614":
+            ap.Transition(
+                lower=D52,
+                upper=P32,
+                A=4.12e7,  # [1]
+                freq=2 * np.pi * 487990081496342.56  # [1]
+            ),
+            "1762":
+            ap.Transition(
+                lower=S12,
+                upper=D52,
+                A=0.04,  # [1]
+                freq=2 * np.pi * 170126433920560.6  # [1]
+            ),
+            "2051":
+            ap.Transition(
+                lower=S12,
+                upper=D32,
+                A=0.04,  # [1]
+                freq=2 * np.pi * 146114407100821.6  # [1]
+            ),
+        }
+
+        super().__init__(
+            B=B,
+            I=3 / 2,
+            levels=levels,
+            transitions=transitions,
+            level_filter=level_filter,
+        )

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -38,7 +38,7 @@ class Ba135(ap.Atom):
         B: typing.Optional[float] = None,
         level_filter: typing.Optional[typing.List[ap.Level]] = None
     ):
-        """43Ca+ atomic structure.
+        """135Ba+ atomic structure.
 
         :param B: B-field in Tesla (can be changed using :meth setB:)
         :param level_filter: list of Levels to include in the simulation, if

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -8,7 +8,7 @@ only ~10% accurate.
 
 The transition frequencies are calculated based on the 138Ba+ frequencies
 from [1] and the isotope shifts in the second reference listed next to
-the freqiency. Where no references are given, the transition frequencies
+the frequency. Where no references are given, the transition frequencies
 were calculated based on transition frequencies between other levels.
 For example the frequency of the 1762 nm transition f(1762) was found
 from f(1762)=f(455)-f(614).

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -6,16 +6,20 @@ A cursory look turned up:
 However, this data is based of calculations done in the late 60s. These are
 only ~10% accurate.
 
-TODO: fix isotope shifts
-
 References:
-[1] - F. Arbes, et al., Zeitschrift fur Physik D: Atoms, Molecules and
-  Clusters, 31, 27 (1994)
-[2] - G. Tommaseo, et al., The European Physical Journal D, 25 (2003)
-[3] - T. P. Harty, et al. Phys. Rev. Lett 113, 220501 (2014)
-[4] - W.  Nortershauser, et al., The European Physical Journal D, 2 (1998)
-[5] - J. Benhelm, et al., PHYSICAL REVIEW A 75, 032506 (2007)
-[6] - A. Kramida, At. Data Nucl. Data Tables 133-134, 101322 (2020)
+[1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
+[2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621, (1990)
+[3] - N. Yu, W. Nagourney, and H. Dehmelt, Phys. Rev. Lett. 78, 4898 (1997)
+[4] - N. J. Stone, Table of nuclear magnetic dipole and electric
+  quadrupole moments, Atomic Data and Nuclear Data Tables, Volume 90,
+  Issue 1 (2005)
+[5] - H. Knab, K. H. Knöll, F. Scheerer and G. Werth, Zeitschrift für
+  Physik D Atoms, Molecules and Clusters volume 25, pages205–208 (1993)
+[6] - W. Becker, G. Werth, Zeitschrift für Physik A Atoms and Nuclei,
+  Volume 311, Issue 1-2, pp. 41-47 (1983)
+[7] - P Villemoes et al, J. Phys. B: At. Mol. Opt. Phys. 26 4289 (1993)
+[8] - Roger E. Silverans, Gustaaf Borghs, Peter De Bisschop, and
+  Marleen Van Hove, Phys. Rev. A 33, 2117 (1986)
 """
 import numpy as np
 import typing
@@ -46,28 +50,28 @@ class Ba135(ap.Atom):
         """
         levels = {
             ground_level: ap.LevelData(
-                g_J=2.00225664,  # [2]
-                g_I=(2 / 3) * 0.838627,  # [3]
-                Ahfs=3591.67011718e6 * consts.h,  # [1]
+                Ahfs=3591.67011745e6 * consts.h,  # [6]
+                g_J=2.0024906,  # [5]
+                g_I=(2 / 3) * 0.83794,  # [4]
             ),
             P12: ap.LevelData(
-                Ahfs=-145.4e6 * consts.h,
-                g_I=(2 / 3) * 0.838627,  # [4]  # [3]
+                Ahfs=664.6e6 * consts.h,  # [7]
+                g_I=(2 / 3) * 0.83794,  # [4]
             ),
             P32: ap.LevelData(
-                Ahfs=-31.4e6 * consts.h,  # [4]
-                Bhfs=-6.9 * consts.h,  # [4]
-                g_I=(2 / 3) * 0.838627,  # [3]
+                Ahfs=113.0e6 * consts.h,  # [7]
+                Bhfs=59.0e6 * consts.h,  # [7]
+                g_I=(2 / 3) * 0.83794,  # [4]
             ),
             D32: ap.LevelData(
-                Ahfs=-47.3e6 * consts.h,  # [4]
-                Bhfs=-3.7 * consts.h,  # [4]
-                g_I=(2 / 3) * 0.838627,  # [3]
+                Ahfs=169.5898e6 * consts.h,  # [8]
+                Bhfs=28.9528 * consts.h,  # [8]
+                g_I=(2 / 3) * 0.83794,  # [4]
             ),
             D52: ap.LevelData(
-                Ahfs=-10.735e6 * consts.h,  # [5]
-                Bhfs=38.688e6 * consts.h,  # [5]
-                g_I=(2 / 3) * 0.838627,  # [3]
+                Ahfs=-10.735e6 * consts.h,  # [8]
+                Bhfs=38.692e6 * consts.h,  # [8]
+                g_I=(2 / 3) * 0.83794,  # [4]
             ),
         }
 
@@ -76,43 +80,43 @@ class Ba135(ap.Atom):
                 lower=S12,
                 upper=P12,
                 A=9.53e7,  # [1]
-                freq=2 * np.pi * 607426317510693.9,  # [1]
+                freq=2 * np.pi * 607426317510693.9,  #
             ),
             "455": ap.Transition(
                 lower=S12,
                 upper=P32,
                 A=1.11e8,  # [1]
-                freq=2 * np.pi * 658116515416903.1,  # [1]
+                freq=2 * np.pi * 658116515416903.1,  #
             ),
             "650": ap.Transition(
                 lower=D32,
                 upper=P12,
                 A=3.1e7,  # [1]
-                freq=2 * np.pi * 461311910409872.25,  # [1]
+                freq=2 * np.pi * 461311910409872.25,  #
             ),
             "585": ap.Transition(
                 lower=D32,
                 upper=P32,
                 A=6.0e6,  # [1]
-                freq=2 * np.pi * 512002108316081.56,  # [1]
+                freq=2 * np.pi * 512002108316081.56,  #
             ),
             "614": ap.Transition(
                 lower=D52,
                 upper=P32,
                 A=4.12e7,  # [1]
-                freq=2 * np.pi * 487990081496342.56,  # [1]
+                freq=2 * np.pi * 487990081496342.56,  #
             ),
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=0.04,  # [1]
-                freq=2 * np.pi * 170126433920560.6,  # [1]
+                A=29e-3,  # [2]
+                freq=2 * np.pi * 170126433920560.6,  #
             ),
             "2051": ap.Transition(
                 lower=S12,
                 upper=D32,
-                A=0.04,  # [1]
-                freq=2 * np.pi * 146114407100821.6,  # [1]
+                A=12.5e-3,  # [3]
+                freq=2 * np.pi * 146114407100821.6,  #
             ),
         }
 

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -6,6 +6,13 @@ A cursory look turned up:
 However, this data is based of calculations done in the late 60s. These are
 only ~10% accurate.
 
+The transition frequencies are calculated based on the 138Ba+ frequencies
+from [1] and the isotope shifts in the second reference listed next to
+the freqiency. Where no references are given, the transition frequencies
+were calculated based on transition frequencies between other levels.
+For example the frequency of the 1762 nm transition f(1762) was found
+from f(1762)=f(455)-f(614).
+
 References:
 [1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
 [2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621, (1990)
@@ -20,6 +27,9 @@ References:
 [7] - P Villemoes et al, J. Phys. B: At. Mol. Opt. Phys. 26 4289 (1993)
 [8] - Roger E. Silverans, Gustaaf Borghs, Peter De Bisschop, and
   Marleen Van Hove, Phys. Rev. A 33, 2117 (1986)
+[9] - K. Wendt, S. A. Ahmad, F. Buchinger, A. C. Mueller, R. Neugart, and
+  E. -W. Otten, Zeitschrift für Physik A Atoms and Nuclei volume 318,
+  pages 125–129 (1984)
 """
 import numpy as np
 import typing
@@ -80,43 +90,43 @@ class Ba135(ap.Atom):
                 lower=S12,
                 upper=P12,
                 A=9.53e7,  # [1]
-                freq=2 * np.pi * 607426317510693.9,  #
+                freq=2 * np.pi * 607426317511042.5,  # [1], [9]
             ),
             "455": ap.Transition(
                 lower=S12,
                 upper=P32,
                 A=1.11e8,  # [1]
-                freq=2 * np.pi * 658116515416903.1,  #
+                freq=2 * np.pi * 658116515417266.0,
             ),
             "650": ap.Transition(
                 lower=D32,
                 upper=P12,
                 A=3.1e7,  # [1]
-                freq=2 * np.pi * 461311910409872.25,  #
+                freq=2 * np.pi * 461311910409954.94,  # [1], [7]
             ),
             "585": ap.Transition(
                 lower=D32,
                 upper=P32,
                 A=6.0e6,  # [1]
-                freq=2 * np.pi * 512002108316081.56,  #
+                freq=2 * np.pi * 512002108316178.56,  # [1], [7]
             ),
             "614": ap.Transition(
                 lower=D52,
                 upper=P32,
                 A=4.12e7,  # [1]
-                freq=2 * np.pi * 487990081496342.56,  #
+                freq=2 * np.pi * 487990081496443.94,  # [1], [7]
             ),
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
                 A=29e-3,  # [2]
-                freq=2 * np.pi * 170126433920560.6,  #
+                freq=2 * np.pi * 170126433920822.06,
             ),
             "2051": ap.Transition(
                 lower=S12,
                 upper=D32,
                 A=12.5e-3,  # [3]
-                freq=2 * np.pi * 146114407100821.6,  #
+                freq=2 * np.pi * 146114407101087.56,
             ),
         }
 

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -48,8 +48,7 @@ class Ba137(ap.Atom):
                 Ahfs=4018.87083385e6 * consts.h,  # [2]
             ),
             P12: ap.LevelData(
-                Ahfs=743.7e6 * consts.h, # [1]
-                g_I=(2 / 3) * -0.93107  # [1]
+                Ahfs=743.7e6 * consts.h, g_I=(2 / 3) * -0.93107  # [1]  # [1]
             ),
             P32: ap.LevelData(
                 Ahfs=126.9e6 * consts.h,  # [5]
@@ -69,54 +68,47 @@ class Ba137(ap.Atom):
         }
 
         transitions = {
-            "493":
-            ap.Transition(
+            "493": ap.Transition(
                 lower=S12,
                 upper=P12,
                 A=9.53e7,  # [1]
-                freq=2 * np.pi * 607426317510693.9  # [1]
+                freq=2 * np.pi * 607426317510693.9,  # [1]
             ),
-            "455":
-            ap.Transition(
+            "455": ap.Transition(
                 lower=S12,
                 upper=P32,
                 A=1.11e8,  # [1]
-                freq=2 * np.pi * 658116515416903.1  # [1]
+                freq=2 * np.pi * 658116515416903.1,  # [1]
             ),
-            "650":
-            ap.Transition(
+            "650": ap.Transition(
                 lower=D32,
                 upper=P12,
                 A=3.1e7,  # [1]
-                freq=2 * np.pi * 461311910409872.25  # [1]
+                freq=2 * np.pi * 461311910409872.25,  # [1]
             ),
-            "585":
-            ap.Transition(
+            "585": ap.Transition(
                 lower=D32,
                 upper=P32,
                 A=6.0e6,  # [1]
-                freq=2 * np.pi * 512002108316081.56  # [1]
+                freq=2 * np.pi * 512002108316081.56,  # [1]
             ),
-            "614":
-            ap.Transition(
+            "614": ap.Transition(
                 lower=D52,
                 upper=P32,
                 A=4.12e7,  # [1]
-                freq=2 * np.pi * 487990081496342.56  # [1]
+                freq=2 * np.pi * 487990081496342.56,  # [1]
             ),
-            "1762":
-            ap.Transition(
+            "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
                 A=0.04,  # [1]
-                freq=2 * np.pi * 170126433920560.6  # [1]
+                freq=2 * np.pi * 170126433920560.6,  # [1]
             ),
-            "2051":
-            ap.Transition(
+            "2051": ap.Transition(
                 lower=S12,
                 upper=D32,
                 A=0.04,  # [1]
-                freq=2 * np.pi * 146114407100821.6  # [1]
+                freq=2 * np.pi * 146114407100821.6,  # [1]
             ),
         }
 

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -16,6 +16,7 @@ TODO: fix isotope shifts
 [5] https://journals.aps.org/pra/pdf/10.1103/PhysRevA.33.2117
 """
 import numpy as np
+import typing
 import scipy.constants as consts
 import atomic_physics as ap
 
@@ -28,7 +29,12 @@ shelf = D52 = ap.Level(n=5, S=1 / 2, L=2, J=5 / 2)
 
 
 class Ba137(ap.Atom):
-    def __init__(self, *, B=None, level_filter=None):
+    def __init__(
+        self,
+        *,
+        B: typing.Optional[float] = None,
+        level_filter: typing.Optional[typing.List[ap.Level]] = None
+    ):
         """137Ba+ atomic structure.
 
         :param B: B-field in Tesla (can be changed using :meth setB:)
@@ -37,7 +43,7 @@ class Ba137(ap.Atom):
         """
         levels = {
             ground_level: ap.LevelData(
-                g_J=2.00225664,  # [3]
+                g_J=2.00225664,  # [2]
                 g_I=(2 / 3) * -0.93107,  # [1]
                 Ahfs=4018.87083385e6 * consts.h,  # [2]
             ),

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -6,6 +6,13 @@ A cursory look turned up:
 However, this data is based of calculations done in the late 60s. These are
 only ~10% accurate.
 
+The transition frequencies are calculated based on the 138Ba+ frequencies
+from [1] and the isotope shifts in the second reference listed next to
+the freqiency. Where no references are given, the transition frequencies
+were calculated based on transition frequencies between other levels.
+For example the frequency of the 1762 nm transition f(1762) was found
+from f(1762)=f(455)-f(614).
+
 References:
 [1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
 [2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621 (1990)
@@ -14,13 +21,16 @@ References:
   quadrupole moments, Atomic Data and Nuclear Data Tables, Volume 90,
   Issue 1 (2005)
 [5] - H. Knab, K. H. Knöll, F. Scheerer and G. Werth, Zeitschrift für
-  Physik D Atoms, Molecules and Clusters volume 25, pages205–208 (1993)
+  Physik D Atoms, Molecules and Clusters volume 25, pages 205–208 (1993)
 [6] - R. Blatt and G. Werth, Phys. Rev. A 25, 1476 (1982)
 [7] - P Villemoes et al, J. Phys. B: At. Mol. Opt. Phys. 26 4289 (1993)
 [8] - Nicholas C. Lewty, Boon Leng Chuah, Radu Cazan, B. K. Sahoo, and
   M. D. Barrett, Opt. Express 21, 7131-7132 (2013)
 [9] - Nicholas C. Lewty, Boon Leng Chuah, Radu Cazan, Murray D. Barrett,
   and B. K. Sahoo, Phys. Rev. A 88, 012518 (2013)
+[10] - K. Wendt, S. A. Ahmad, F. Buchinger, A. C. Mueller, R. Neugart, and
+  E. -W. Otten, Zeitschrift für Physik A Atoms and Nuclei volume 318,
+  pages 125–129 (1984)
 """
 import numpy as np
 import typing
@@ -80,43 +90,43 @@ class Ba137(ap.Atom):
                 lower=S12,
                 upper=P12,
                 A=9.53e7,  # [1]
-                freq=2 * np.pi * 607426317510693.9,  #
+                freq=2 * np.pi * 607426317510965.0,  # [1], [10]
             ),
             "455": ap.Transition(
                 lower=S12,
                 upper=P32,
                 A=1.11e8,  # [1]
-                freq=2 * np.pi * 658116515416903.1,  #
+                freq=2 * np.pi * 658116515417166.6,
             ),
             "650": ap.Transition(
                 lower=D32,
                 upper=P12,
                 A=3.1e7,  # [1]
-                freq=2 * np.pi * 461311910409872.25,  #
+                freq=2 * np.pi * 461311910409885.25,  # [1], [7]
             ),
             "585": ap.Transition(
                 lower=D32,
                 upper=P32,
                 A=6.0e6,  # [1]
-                freq=2 * np.pi * 512002108316081.56,  #
+                freq=2 * np.pi * 512002108316086.9,  # [1], [7]
             ),
             "614": ap.Transition(
                 lower=D52,
                 upper=P32,
                 A=4.12e7,  # [1]
-                freq=2 * np.pi * 487990081496342.56,  #
+                freq=2 * np.pi * 487990081496344.9,  # [1], [7]
             ),
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
                 A=29e-3,  # [2]
-                freq=2 * np.pi * 170126433920560.6,  #
+                freq=2 * np.pi * 170126433920558.25,
             ),
             "2051": ap.Transition(
                 lower=S12,
                 upper=D32,
                 A=12.5e-3,  # [3]
-                freq=2 * np.pi * 146114407100821.6,  #
+                freq=2 * np.pi * 146114407101079.75,
             ),
         }
 

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -6,14 +6,21 @@ A cursory look turned up:
 However, this data is based of calculations done in the late 60s. These are
 only ~10% accurate.
 
-TODO: fix isotope shifts
-
-[1] https://journals.aps.org/pr/pdf/10.1103/PhysRev.102.1334
-[2] Hucul, David, et al. "Spectroscopy of a synthetic trapped ion qubit." Physical review letters 119.10 (2017): 100501.
-    https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.119.100501
-[3] - G. Tommaseo, et al., The European Physical Journal D, 25 (2003)
-[4] A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
-[5] https://journals.aps.org/pra/pdf/10.1103/PhysRevA.33.2117
+References:
+[1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
+[2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621 (1990)
+[3] - N. Yu, W. Nagourney, and H. Dehmelt, Phys. Rev. Lett. 78, 4898 (1997)
+[4] - N. J. Stone, Table of nuclear magnetic dipole and electric
+  quadrupole moments, Atomic Data and Nuclear Data Tables, Volume 90,
+  Issue 1 (2005)
+[5] - H. Knab, K. H. Knöll, F. Scheerer and G. Werth, Zeitschrift für
+  Physik D Atoms, Molecules and Clusters volume 25, pages205–208 (1993)
+[6] - R. Blatt and G. Werth, Phys. Rev. A 25, 1476 (1982)
+[7] - P Villemoes et al, J. Phys. B: At. Mol. Opt. Phys. 26 4289 (1993)
+[8] - Nicholas C. Lewty, Boon Leng Chuah, Radu Cazan, B. K. Sahoo, and
+  M. D. Barrett, Opt. Express 21, 7131-7132 (2013)
+[9] - Nicholas C. Lewty, Boon Leng Chuah, Radu Cazan, Murray D. Barrett,
+  and B. K. Sahoo, Phys. Rev. A 88, 012518 (2013)
 """
 import numpy as np
 import typing
@@ -43,27 +50,28 @@ class Ba137(ap.Atom):
         """
         levels = {
             ground_level: ap.LevelData(
-                g_J=2.00225664,  # [2]
-                g_I=(2 / 3) * -0.93107,  # [1]
-                Ahfs=4018.87083385e6 * consts.h,  # [2]
+                Ahfs=4018.87083384e6 * consts.h,  # [6]
+                g_J=2.0024906,  # [5]
+                g_I=(2 / 3) * 0.93737,  # [4]
             ),
             P12: ap.LevelData(
-                Ahfs=743.7e6 * consts.h, g_I=(2 / 3) * -0.93107  # [1]  # [1]
+                Ahfs=743.7e6 * consts.h,  # [7]
+                g_I=(2 / 3) * 0.93737,  # [4]
             ),
             P32: ap.LevelData(
-                Ahfs=126.9e6 * consts.h,  # [5]
-                Bhfs=92.8e6 * consts.h,  # [5]
-                g_I=(2 / 3) * -0.93107,  # [1]
+                Ahfs=127.2e6 * consts.h,  # [7]
+                Bhfs=92.5e6 * consts.h,  # [7]
+                g_I=(2 / 3) * 0.93737,  # [4]
             ),
             D32: ap.LevelData(
-                Ahfs=189.7288e6 * consts.h,  # [2]
-                Bhfs=44.5417e6 * consts.h,  # [2]
-                g_I=(2 / 3) * -0.93107,  # [1]
+                Ahfs=189.731101e6 * consts.h,  # [8]
+                Bhfs=44.536612e6 * consts.h,  # [8]
+                g_I=(2 / 3) * 0.93737,  # [4]
             ),
             D52: ap.LevelData(
-                Ahfs=-12.028e6 * consts.h,  # [5]
-                Bhfs=59.533e6 * consts.h,  # [5]
-                g_I=(2 / 3) * -0.93107,  # [1]
+                Ahfs=-12.029234e6 * consts.h,  # [9]
+                Bhfs=59.52552e6 * consts.h,  # [9]
+                g_I=(2 / 3) * 0.93737,  # [4]
             ),
         }
 
@@ -72,43 +80,43 @@ class Ba137(ap.Atom):
                 lower=S12,
                 upper=P12,
                 A=9.53e7,  # [1]
-                freq=2 * np.pi * 607426317510693.9,  # [1]
+                freq=2 * np.pi * 607426317510693.9,  #
             ),
             "455": ap.Transition(
                 lower=S12,
                 upper=P32,
                 A=1.11e8,  # [1]
-                freq=2 * np.pi * 658116515416903.1,  # [1]
+                freq=2 * np.pi * 658116515416903.1,  #
             ),
             "650": ap.Transition(
                 lower=D32,
                 upper=P12,
                 A=3.1e7,  # [1]
-                freq=2 * np.pi * 461311910409872.25,  # [1]
+                freq=2 * np.pi * 461311910409872.25,  #
             ),
             "585": ap.Transition(
                 lower=D32,
                 upper=P32,
                 A=6.0e6,  # [1]
-                freq=2 * np.pi * 512002108316081.56,  # [1]
+                freq=2 * np.pi * 512002108316081.56,  #
             ),
             "614": ap.Transition(
                 lower=D52,
                 upper=P32,
                 A=4.12e7,  # [1]
-                freq=2 * np.pi * 487990081496342.56,  # [1]
+                freq=2 * np.pi * 487990081496342.56,  #
             ),
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=0.04,  # [1]
-                freq=2 * np.pi * 170126433920560.6,  # [1]
+                A=29e-3,  # [2]
+                freq=2 * np.pi * 170126433920560.6,  #
             ),
             "2051": ap.Transition(
                 lower=S12,
                 upper=D32,
-                A=0.04,  # [1]
-                freq=2 * np.pi * 146114407100821.6,  # [1]
+                A=12.5e-3,  # [3]
+                freq=2 * np.pi * 146114407100821.6,  #
             ),
         }
 

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -1,0 +1,123 @@
+""" 137Ba+
+
+TODO: We need a reference for the Einstein A values
+A cursory look turned up:
+    Kramida, A., et al., NIST Atomic Spectra Database (ver. 5.8), [Online].
+However, this data is based of calculations done in the late 60s. These are
+only ~10% accurate.
+
+TODO: fix isotope shifts
+
+[1] https://journals.aps.org/pr/pdf/10.1103/PhysRev.102.1334
+[2] Hucul, David, et al. "Spectroscopy of a synthetic trapped ion qubit." Physical review letters 119.10 (2017): 100501.
+    https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.119.100501
+[3] - G. Tommaseo, et al., The European Physical Journal D, 25 (2003)
+[4] A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
+[5] https://journals.aps.org/pra/pdf/10.1103/PhysRevA.33.2117
+"""
+import numpy as np
+import scipy.constants as consts
+import atomic_physics as ap
+
+# level aliases
+ground_level = S12 = ap.Level(n=6, S=1 / 2, L=0, J=1 / 2)
+P12 = ap.Level(n=6, S=1 / 2, L=1, J=1 / 2)
+P32 = ap.Level(n=6, S=1 / 2, L=1, J=3 / 2)
+D32 = ap.Level(n=5, S=1 / 2, L=2, J=3 / 2)
+shelf = D52 = ap.Level(n=5, S=1 / 2, L=2, J=5 / 2)
+
+
+class Ba137(ap.Atom):
+    def __init__(self, *, B=None, level_filter=None):
+        """137Ba+ atomic structure.
+
+        :param B: B-field in Tesla (can be changed using :meth setB:)
+        :param level_filter: list of Levels to include in the simulation, if
+            None we include all levels.
+        """
+        levels = {
+            ground_level: ap.LevelData(
+                g_J=2.00225664,  # [3]
+                g_I=(2 / 3) * -0.93107,  # [1]
+                Ahfs=4018.87083385e6 * consts.h,  # [2]
+            ),
+            P12: ap.LevelData(
+                Ahfs=743.7e6 * consts.h, # [1]
+                g_I=(2 / 3) * -0.93107  # [1]
+            ),
+            P32: ap.LevelData(
+                Ahfs=126.9e6 * consts.h,  # [5]
+                Bhfs=92.8e6 * consts.h,  # [5]
+                g_I=(2 / 3) * -0.93107,  # [1]
+            ),
+            D32: ap.LevelData(
+                Ahfs=44.5417 * consts.h,  # [2]
+                Bhfs=189.7288e6 * consts.h,  # [2]
+                g_I=(2 / 3) * -0.93107,  # [1]
+            ),
+            D52: ap.LevelData(
+                Ahfs=-12.028e6 * consts.h,  # [5]
+                Bhfs=59.533e6 * consts.h,  # [5]
+                g_I=(2 / 3) * -0.93107,  # [1]
+            ),
+        }
+
+        transitions = {
+            "493":
+            ap.Transition(
+                lower=S12,
+                upper=P12,
+                A=9.53e7,  # [1]
+                freq=2 * np.pi * 607426317510693.9  # [1]
+            ),
+            "455":
+            ap.Transition(
+                lower=S12,
+                upper=P32,
+                A=1.11e8,  # [1]
+                freq=2 * np.pi * 658116515416903.1  # [1]
+            ),
+            "650":
+            ap.Transition(
+                lower=D32,
+                upper=P12,
+                A=3.1e7,  # [1]
+                freq=2 * np.pi * 461311910409872.25  # [1]
+            ),
+            "585":
+            ap.Transition(
+                lower=D32,
+                upper=P32,
+                A=6.0e6,  # [1]
+                freq=2 * np.pi * 512002108316081.56  # [1]
+            ),
+            "614":
+            ap.Transition(
+                lower=D52,
+                upper=P32,
+                A=4.12e7,  # [1]
+                freq=2 * np.pi * 487990081496342.56  # [1]
+            ),
+            "1762":
+            ap.Transition(
+                lower=S12,
+                upper=D52,
+                A=0.04,  # [1]
+                freq=2 * np.pi * 170126433920560.6  # [1]
+            ),
+            "2051":
+            ap.Transition(
+                lower=S12,
+                upper=D32,
+                A=0.04,  # [1]
+                freq=2 * np.pi * 146114407100821.6  # [1]
+            ),
+        }
+
+        super().__init__(
+            B=B,
+            I=3 / 2,
+            levels=levels,
+            transitions=transitions,
+            level_filter=level_filter,
+        )

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -8,7 +8,7 @@ only ~10% accurate.
 
 The transition frequencies are calculated based on the 138Ba+ frequencies
 from [1] and the isotope shifts in the second reference listed next to
-the freqiency. Where no references are given, the transition frequencies
+the frequency. Where no references are given, the transition frequencies
 were calculated based on transition frequencies between other levels.
 For example the frequency of the 1762 nm transition f(1762) was found
 from f(1762)=f(455)-f(614).

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -120,7 +120,7 @@ class Ba137(ap.Atom):
                 lower=S12,
                 upper=D52,
                 A=29e-3,  # [2]
-                freq=2 * np.pi * 170126433920558.25,
+                freq=2 * np.pi * 170126433920821.75,
             ),
             "2051": ap.Transition(
                 lower=S12,

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -57,8 +57,8 @@ class Ba137(ap.Atom):
                 g_I=(2 / 3) * -0.93107,  # [1]
             ),
             D32: ap.LevelData(
-                Ahfs=44.5417 * consts.h,  # [2]
-                Bhfs=189.7288e6 * consts.h,  # [2]
+                Ahfs=189.7288e6 * consts.h,  # [2]
+                Bhfs=44.5417e6 * consts.h,  # [2]
                 g_I=(2 / 3) * -0.93107,  # [1]
             ),
             D52: ap.LevelData(

--- a/atomic_physics/ions/ba138.py
+++ b/atomic_physics/ions/ba138.py
@@ -17,7 +17,7 @@ shelf = D52 = ap.Level(n=5, S=1 / 2, L=2, J=5 / 2)
 
 class Ba138(ap.Atom):
     def __init__(self, *, B=None, level_filter=None):
-        """ 88Sr+ atomic structure.
+        """88Sr+ atomic structure.
 
         :param B: B-field in Tesla (can be changed using :meth setB:)
         :param level_filter: list of Levels to include in the simulation, if
@@ -28,63 +28,54 @@ class Ba138(ap.Atom):
             P12: ap.LevelData(),
             P32: ap.LevelData(),
             D32: ap.LevelData(),
-            D52: ap.LevelData()
+            D52: ap.LevelData(),
         }
 
         transitions = {
-            "493":
-            ap.Transition(
+            "493": ap.Transition(
                 lower=S12,
                 upper=P12,
                 A=9.53e7,  # [1]
-                freq=2 * np.pi * 607426317510693.9  # [1]
+                freq=2 * np.pi * 607426317510693.9,  # [1]
             ),
-            "455":
-            ap.Transition(
+            "455": ap.Transition(
                 lower=S12,
                 upper=P32,
                 A=1.11e8,  # [1]
-                freq=2 * np.pi * 658116515416903.1  # [1]
+                freq=2 * np.pi * 658116515416903.1,  # [1]
             ),
-            "650":
-            ap.Transition(
+            "650": ap.Transition(
                 lower=D32,
                 upper=P12,
                 A=3.1e7,  # [1]
-                freq=2 * np.pi * 461311910409872.25  # [1]
+                freq=2 * np.pi * 461311910409872.25,  # [1]
             ),
-            "585":
-            ap.Transition(
+            "585": ap.Transition(
                 lower=D32,
                 upper=P32,
                 A=6.0e6,  # [1]
-                freq=2 * np.pi * 512002108316081.56  # [1]
+                freq=2 * np.pi * 512002108316081.56,  # [1]
             ),
-            "614":
-            ap.Transition(
+            "614": ap.Transition(
                 lower=D52,
                 upper=P32,
                 A=4.12e7,  # [1]
-                freq=2 * np.pi * 487990081496342.56  # [1]
+                freq=2 * np.pi * 487990081496342.56,  # [1]
             ),
-            "1762":
-            ap.Transition(
+            "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
                 A=0.04,  # [1]
-                freq=2 * np.pi * 170126433920560.6  # [1]
+                freq=2 * np.pi * 170126433920560.6,  # [1]
             ),
-            "2051":
-            ap.Transition(
+            "2051": ap.Transition(
                 lower=S12,
                 upper=D32,
                 A=0.04,  # [1]
-                freq=2 * np.pi * 146114407100821.6  # [1]
+                freq=2 * np.pi * 146114407100821.6,  # [1]
             ),
         }
 
-        super().__init__(B=B,
-                         I=0,
-                         levels=levels,
-                         transitions=transitions,
-                         level_filter=level_filter)
+        super().__init__(
+            B=B, I=0, levels=levels, transitions=transitions, level_filter=level_filter
+        )

--- a/atomic_physics/ions/ba138.py
+++ b/atomic_physics/ions/ba138.py
@@ -12,7 +12,6 @@ References:
 [3] - N. Yu, W. Nagourney, and H. Dehmelt, Phys. Rev. Lett. 78, 4898 (1997)
  """
 import numpy as np
-import scipy.constants as consts
 import atomic_physics as ap
 
 # level aliases

--- a/atomic_physics/ions/ba138.py
+++ b/atomic_physics/ions/ba138.py
@@ -1,7 +1,15 @@
 """ 138Ba+
 
+TODO: We need a reference for the Einstein A values
+A cursory look turned up:
+    Kramida, A., et al., NIST Atomic Spectra Database (ver. 5.8), [Online].
+However, this data is based of calculations done in the late 60s. These are
+only ~10% accurate.
+
 References:
-[1] A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
+[1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
+[2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621, (1990)
+[3] - N. Yu, W. Nagourney, and H. Dehmelt, Phys. Rev. Lett. 78, 4898 (1997)
  """
 import numpy as np
 import scipy.constants as consts
@@ -65,13 +73,13 @@ class Ba138(ap.Atom):
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=0.04,  # [1]
+                A=29e-3,  # [2]
                 freq=2 * np.pi * 170126433920560.6,  # [1]
             ),
             "2051": ap.Transition(
                 lower=S12,
                 upper=D32,
-                A=0.04,  # [1]
+                A=12.5e-3,  # [3]
                 freq=2 * np.pi * 146114407100821.6,  # [1]
             ),
         }

--- a/atomic_physics/ions/ba138.py
+++ b/atomic_physics/ions/ba138.py
@@ -25,7 +25,7 @@ shelf = D52 = ap.Level(n=5, S=1 / 2, L=2, J=5 / 2)
 
 class Ba138(ap.Atom):
     def __init__(self, *, B=None, level_filter=None):
-        """88Sr+ atomic structure.
+        """138Ba+ atomic structure.
 
         :param B: B-field in Tesla (can be changed using :meth setB:)
         :param level_filter: list of Levels to include in the simulation, if

--- a/atomic_physics/ions/ba138.py
+++ b/atomic_physics/ions/ba138.py
@@ -1,0 +1,90 @@
+""" 138Ba+
+
+References:
+[1] A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
+ """
+import numpy as np
+import scipy.constants as consts
+import atomic_physics as ap
+
+# level aliases
+ground_level = S12 = ap.Level(n=6, S=1 / 2, L=0, J=1 / 2)
+P12 = ap.Level(n=6, S=1 / 2, L=1, J=1 / 2)
+P32 = ap.Level(n=6, S=1 / 2, L=1, J=3 / 2)
+D32 = ap.Level(n=5, S=1 / 2, L=2, J=3 / 2)
+shelf = D52 = ap.Level(n=5, S=1 / 2, L=2, J=5 / 2)
+
+
+class Ba138(ap.Atom):
+    def __init__(self, *, B=None, level_filter=None):
+        """ 88Sr+ atomic structure.
+
+        :param B: B-field in Tesla (can be changed using :meth setB:)
+        :param level_filter: list of Levels to include in the simulation, if
+            None we include all levels.
+        """
+        levels = {
+            ground_level: ap.LevelData(),
+            P12: ap.LevelData(),
+            P32: ap.LevelData(),
+            D32: ap.LevelData(),
+            D52: ap.LevelData()
+        }
+
+        transitions = {
+            "493":
+            ap.Transition(
+                lower=S12,
+                upper=P12,
+                A=9.53e7,  # [1]
+                freq=2 * np.pi * 607426317510693.9  # [1]
+            ),
+            "455":
+            ap.Transition(
+                lower=S12,
+                upper=P32,
+                A=1.11e8,  # [1]
+                freq=2 * np.pi * 658116515416903.1  # [1]
+            ),
+            "650":
+            ap.Transition(
+                lower=D32,
+                upper=P12,
+                A=3.1e7,  # [1]
+                freq=2 * np.pi * 461311910409872.25  # [1]
+            ),
+            "585":
+            ap.Transition(
+                lower=D32,
+                upper=P32,
+                A=6.0e6,  # [1]
+                freq=2 * np.pi * 512002108316081.56  # [1]
+            ),
+            "614":
+            ap.Transition(
+                lower=D52,
+                upper=P32,
+                A=4.12e7,  # [1]
+                freq=2 * np.pi * 487990081496342.56  # [1]
+            ),
+            "1762":
+            ap.Transition(
+                lower=S12,
+                upper=D52,
+                A=0.04,  # [1]
+                freq=2 * np.pi * 170126433920560.6  # [1]
+            ),
+            "2051":
+            ap.Transition(
+                lower=S12,
+                upper=D32,
+                A=0.04,  # [1]
+                freq=2 * np.pi * 146114407100821.6  # [1]
+            ),
+        }
+
+        super().__init__(B=B,
+                         I=0,
+                         levels=levels,
+                         transitions=transitions,
+                         level_filter=level_filter)

--- a/atomic_physics/ions/ba138.py
+++ b/atomic_physics/ions/ba138.py
@@ -6,6 +6,11 @@ A cursory look turned up:
 However, this data is based of calculations done in the late 60s. These are
 only ~10% accurate.
 
+Where no references are given next to the transition frequencies, they
+were calculated based on transition frequencies between other levels.
+For example the frequency of the 1762 nm transition f(1762) was found
+from f(1762)=f(455)-f(614).
+
 References:
 [1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
 [2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621, (1990)
@@ -73,13 +78,13 @@ class Ba138(ap.Atom):
                 lower=S12,
                 upper=D52,
                 A=29e-3,  # [2]
-                freq=2 * np.pi * 170126433920560.6,  # [1]
+                freq=2 * np.pi * 170126433920560.6,
             ),
             "2051": ap.Transition(
                 lower=S12,
                 upper=D32,
                 A=12.5e-3,  # [3]
-                freq=2 * np.pi * 146114407100821.6,  # [1]
+                freq=2 * np.pi * 146114407100821.62,
             ),
         }
 


### PR DESCRIPTION
Add atomic structure data for $\mathrm{^{138}Ba^+}$, $\mathrm{^{137}Ba^+}$, $\mathrm{^{135}Ba^+}$, and $\mathrm{^{133}Ba^+}$.