### PR TITLE
common: check I>1/2 in setB

### DIFF
--- a/atomic_physics/common.py
+++ b/atomic_physics/common.py
@@ -363,7 +363,7 @@ class Atom:
                 H += -gI * _uN * B * Iz
                 H += data.Ahfs * IdotJ
 
-                if J > 1 / 2:
+                if J > 1 / 2 and I > 1 / 2:
                     IdotJ2 = np.linalg.matrix_power(IdotJ, 2)
                     ident = np.identity(I_dim * J_dim)
                     H += (

--- a/atomic_physics/tests/test_spin_half.py
+++ b/atomic_physics/tests/test_spin_half.py
@@ -1,0 +1,41 @@
+"""Test Spin 1/2 nuclei"""
+import unittest
+from atomic_physics.ions import ba133
+from atomic_physics.utils import Lande_g
+import numpy as np
+import scipy.constants as ct
+
+
+def _gF(F, J, I, gJ):
+    return gJ * (F * (F + 1) + J * (J + 1) - I * (I + 1)) / (2 * F * (F + 1))
+
+
+class TestSpinHalf(unittest.TestCase):
+    """Test setB() for spin-half nuclei"""
+
+    def test_hyperfine(self):
+        level = ba133.ground_level
+        ion = ba133.Ba133(level_filter=[level])
+        B = 0.1e-4
+        ion.setB(B)
+        E_0_0 = ion.E[ion.index(level, 0, F=0)]
+        E_1_0 = ion.E[ion.index(level, 0, F=1)]
+
+        Ahfs = 2 * np.pi * 9925.45355459e6
+
+        self.assertAlmostEqual(abs(E_0_0 - E_1_0) / 1e6, Ahfs / 1e6, 4)
+
+    def test_zeeman(self):
+        level = ba133.ground_level
+        ion = ba133.Ba133(level_filter=[level])
+        B = 10e-4
+        ion.setB(B)
+        E_1_0 = ion.E[ion.index(level, 0, F=1)]
+        E_1_1 = ion.E[ion.index(level, 1, F=1)]
+
+        gJ = Lande_g(level)
+        gF = _gF(1, 1 / 2, 1 / 2, gJ)
+        muB = ct.physical_constants["Bohr magneton"][0]
+        E_Zeeman = gF * muB * B / ct.hbar
+
+        self.assertAlmostEqual(abs(E_1_0 - E_1_1) / 1e6, E_Zeeman / 1e6, 0)


### PR DESCRIPTION
Currently working with the ground level of spin-1/2 nuclei fails as it gives 0 denominator in the [Hamiltonian](https://github.com/OxfordIonTrapGroup/atomic_physics/blob/b32491c9877e9c758a4613207005e822de82f393/atomic_physics/common.py#L369) in `setB`. Hence, we need to check that both `J > 1/2` and `I > 1/2`.