### PR TITLE
hfs sign test

### DIFF
--- a/atomic_physics/tests/test_hfs_sign.py
+++ b/atomic_physics/tests/test_hfs_sign.py
@@ -1,0 +1,33 @@
+"""Test hfs constant sign"""
+import unittest
+from atomic_physics.ions import ba133, ba137
+
+
+class TesLevel(unittest.TestCase):
+    """
+    Test hfs constant sign
+    """
+
+    def test_positive_hfs(self):
+        level = ba137.ground_level
+        ion = ba137.Ba137(B=100e-4, level_filter=[level])
+
+        # check that states in F=1 have indices 0-2
+        for i in range(3):
+            self.assertEqual(ion.index(level, -(i-1), F=1), i)
+
+        # check that states in F=2 have indices 3-7
+        for i in range(5):
+            self.assertEqual(ion.index(level, i-2, F=2), i+3)
+
+    def test_negative_hfs(self):
+        level = ba133.ground_level
+        ion = ba133.Ba133(B=100e-4, level_filter=[level])
+
+        # check that states in F=1 have indices 0-2
+        for i in range(3):
+            self.assertEqual(ion.index(level, i-1, F=1), i)
+
+        # check that F=0, mF=0 has index 3
+        self.assertEqual(ion.index(level, 0, F=0), 3)
+

--- a/atomic_physics/tests/test_level.py
+++ b/atomic_physics/tests/test_level.py
@@ -1,4 +1,4 @@
-"""Test Spin 1/2 nuclei"""
+"""Test level assignment"""
 import unittest
 from atomic_physics.ions import ca40
 
@@ -20,3 +20,4 @@ class TesLevel(unittest.TestCase):
         for i in range(6):
             self.assertEqual(ion.level(i + 2).L, 2)
             self.assertEqual(ion.level(i + 2).J, 2.5)
+


### PR DESCRIPTION
Add test to check ordering of states for both positive and negative hyperfine constants.