### PR TITLE
Update reference and value for Ba+ D5/2 lifetime

### DIFF
--- a/atomic_physics/ions/ba133.py
+++ b/atomic_physics/ions/ba133.py
@@ -9,7 +9,8 @@ from f(1762)=f(455)-f(614).
 
 References:
 [1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
-[2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621, (1990)
+[2] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
+ M. S. Safronova, and M. D. Barrett Phys. Rev. A 101, 062515 (2020)
 [3] - N. Yu, W. Nagourney, and H. Dehmelt, Phys. Rev. Lett. 78, 4898 (1997)
 [4] - N. J. Stone, Table of nuclear magnetic dipole and electric
   quadrupole moments, Atomic Data and Nuclear Data Tables, Volume 90,
@@ -20,8 +21,6 @@ References:
   Wesley C. Campbell, Phys. Rev. Lett. 119, 100501 (2017)
 [7] - J.E. Christensen, D. Hucul, W.C. Campbell et al.,
   npj Quantum Inf 6, 35 (2020).
-[8] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
- M. S. Safronova, and M. D. Barrett Phys. Rev. A 101, 062515 (2020)
 """
 import numpy as np
 import typing
@@ -108,7 +107,7 @@ class Ba133(ap.Atom):
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=1 / 30.14,  # [8]
+                A=1 / 30.14,  # [2]
                 freq=2 * np.pi * 170126433920702.56,
             ),
             "2051": ap.Transition(

--- a/atomic_physics/ions/ba133.py
+++ b/atomic_physics/ions/ba133.py
@@ -20,6 +20,8 @@ References:
   Wesley C. Campbell, Phys. Rev. Lett. 119, 100501 (2017)
 [7] - J.E. Christensen, D. Hucul, W.C. Campbell et al.,
   npj Quantum Inf 6, 35 (2020).
+[8] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
+ M. S. Safronova, and M. D. Barrett Phys. Rev. A 101, 062515 (2020)
 """
 import numpy as np
 import typing
@@ -106,7 +108,7 @@ class Ba133(ap.Atom):
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=29e-3,  # [2]
+                A=1 / 30.14,  # [8]
                 freq=2 * np.pi * 170126433920702.56,
             ),
             "2051": ap.Transition(

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -9,7 +9,8 @@ from f(1762)=f(455)-f(614).
 
 References:
 [1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
-[2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621, (1990)
+[2] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
+ M. S. Safronova, and M. D. Barrett Phys. Rev. A 101, 062515 (2020)
 [3] - N. Yu, W. Nagourney, and H. Dehmelt, Phys. Rev. Lett. 78, 4898 (1997)
 [4] - N. J. Stone, Table of nuclear magnetic dipole and electric
   quadrupole moments, Atomic Data and Nuclear Data Tables, Volume 90,
@@ -24,8 +25,6 @@ References:
 [9] - K. Wendt, S. A. Ahmad, F. Buchinger, A. C. Mueller, R. Neugart, and
   E. -W. Otten, Zeitschrift für Physik A Atoms and Nuclei volume 318,
   pages 125–129 (1984)
-[10] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
- M. S. Safronova, and M. D. Barrett Phys. Rev. A 101, 062515 (2020)
 """
 import numpy as np
 import typing
@@ -115,7 +114,7 @@ class Ba135(ap.Atom):
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=1 / 30.14,  # [10]
+                A=1 / 30.14,  # [2]
                 freq=2 * np.pi * 170126433920822.06,
             ),
             "2051": ap.Transition(

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -24,6 +24,8 @@ References:
 [9] - K. Wendt, S. A. Ahmad, F. Buchinger, A. C. Mueller, R. Neugart, and
   E. -W. Otten, Zeitschrift für Physik A Atoms and Nuclei volume 318,
   pages 125–129 (1984)
+[10] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
+ M. S. Safronova, and M. D. Barrett Phys. Rev. A 101, 062515 (2020)
 """
 import numpy as np
 import typing
@@ -113,7 +115,7 @@ class Ba135(ap.Atom):
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=29e-3,  # [2]
+                A=1 / 30.14,  # [10]
                 freq=2 * np.pi * 170126433920822.06,
             ),
             "2051": ap.Transition(

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -25,6 +25,8 @@ References:
 [10] - K. Wendt, S. A. Ahmad, F. Buchinger, A. C. Mueller, R. Neugart, and
   E. -W. Otten, Zeitschrift für Physik A Atoms and Nuclei volume 318,
   pages 125–129 (1984)
+[11] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
+ M. S. Safronova, and M. D. Barrett Phys. Rev. A 101, 062515 (2020)
 """
 import numpy as np
 import typing
@@ -113,7 +115,7 @@ class Ba137(ap.Atom):
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=29e-3,  # [2]
+                A=1 / 30.14,  # [11]
                 freq=2 * np.pi * 170126433920821.75,
             ),
             "2051": ap.Transition(

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -9,7 +9,8 @@ from f(1762)=f(455)-f(614).
 
 References:
 [1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
-[2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621 (1990)
+[2] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
+ M. S. Safronova, and M. D. Barrett Phys. Rev. A 101, 062515 (2020)
 [3] - N. Yu, W. Nagourney, and H. Dehmelt, Phys. Rev. Lett. 78, 4898 (1997)
 [4] - N. J. Stone, Table of nuclear magnetic dipole and electric
   quadrupole moments, Atomic Data and Nuclear Data Tables, Volume 90,
@@ -25,8 +26,6 @@ References:
 [10] - K. Wendt, S. A. Ahmad, F. Buchinger, A. C. Mueller, R. Neugart, and
   E. -W. Otten, Zeitschrift für Physik A Atoms and Nuclei volume 318,
   pages 125–129 (1984)
-[11] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
- M. S. Safronova, and M. D. Barrett Phys. Rev. A 101, 062515 (2020)
 """
 import numpy as np
 import typing
@@ -115,7 +114,7 @@ class Ba137(ap.Atom):
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=1 / 30.14,  # [11]
+                A=1 / 30.14,  # [2]
                 freq=2 * np.pi * 170126433920821.75,
             ),
             "2051": ap.Transition(

--- a/atomic_physics/ions/ba138.py
+++ b/atomic_physics/ions/ba138.py
@@ -9,6 +9,8 @@ References:
 [1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
 [2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621, (1990)
 [3] - N. Yu, W. Nagourney, and H. Dehmelt, Phys. Rev. Lett. 78, 4898 (1997)
+[4] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
+ M. S. Safronova, and M. D. Barrett Phys. Rev. A 101, 062515 (2020)
  """
 import numpy as np
 import atomic_physics as ap
@@ -71,7 +73,7 @@ class Ba138(ap.Atom):
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=29e-3,  # [2]
+                A=1 / 30.14,  # [4]
                 freq=2 * np.pi * 170126433920560.6,
             ),
             "2051": ap.Transition(

--- a/atomic_physics/ions/ba138.py
+++ b/atomic_physics/ions/ba138.py
@@ -7,11 +7,10 @@ from f(1762)=f(455)-f(614).
 
 References:
 [1] - A. Kramida, NIST Atomic Spectra Database (ver. 5.9) (2021)
-[2] - A. A. Madej and J. D. Sankey, Phys. Rev. A 41, 2621, (1990)
-[3] - N. Yu, W. Nagourney, and H. Dehmelt, Phys. Rev. Lett. 78, 4898 (1997)
-[4] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
+[2] - Zhiqiang Zhang, K. J. Arnold, S. R. Chanu, R. Kaewuam,
  M. S. Safronova, and M. D. Barrett Phys. Rev. A 101, 062515 (2020)
- """
+[3] - N. Yu, W. Nagourney, and H. Dehmelt, Phys. Rev. Lett. 78, 4898 (1997)
+"""
 import numpy as np
 import atomic_physics as ap
 
@@ -73,7 +72,7 @@ class Ba138(ap.Atom):
             "1762": ap.Transition(
                 lower=S12,
                 upper=D52,
-                A=1 / 30.14,  # [4]
+                A=1 / 30.14,  # [2]
                 freq=2 * np.pi * 170126433920560.6,
             ),
             "2051": ap.Transition(


### PR DESCRIPTION
I've put the A constant as 1/T for readability. Goes against convention in the codebase, but I think this makes it clearer where the number comes from.