### PR TITLE
Add initial guess to field_insensitive_point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.egg-info/
 /dist
+.DS_Store


### PR DESCRIPTION
The bounds `B_min` and `B_max` in `utils.field_insensitive_point` were unused. The root finder currently in use does not support parameter bounds, so I added an initial guess parameter itself. 

For now, to avoid breaking, I've kept `B_min` and `B_max` in but throw a warning if there's an attempt to set them. We could decide whether we want to implement or remove them in a future PR.