### PR TITLE
Avoid deprecation warning on NumPy 1.25+

### DIFF
--- a/atomic_physics/common.py
+++ b/atomic_physics/common.py
@@ -209,9 +209,9 @@ class Atom:
             MJvec = self.MJ[lev]
             inds = np.logical_and(inds, MJvec == MJ)
 
-        inds = np.argwhere(inds)
+        inds = np.nonzero(inds)[0]
         if len(inds) == 1:
-            inds = int(inds)
+            inds = inds[0]
         return inds + self.levels[level]._start_ind
 
     def level(self, state: int):


### PR DESCRIPTION
Single-element (but >0D) arrays can no longer be converted
to their values using int(), etc.
