### PR TITLE
Add measured gJ value of the D5/2 state to Ca40

### DIFF
--- a/atomic_physics/ions/ca40.py
+++ b/atomic_physics/ions/ca40.py
@@ -3,6 +3,7 @@
 References:
 [1] - A. Kramida, At. Data Nucl. Data Tables 133-134, 101322 (2020)
 [2] - T. P. Harty, DPhil Thesis (2013)
+[3] - M. Chwalla et all, PRL 102, 023002 (2009)
 """
 import numpy as np
 import typing
@@ -35,7 +36,7 @@ class Ca40(ap.Atom):
             P12: ap.LevelData(),
             P32: ap.LevelData(),
             D32: ap.LevelData(),
-            D52: ap.LevelData(),
+            D52: ap.LevelData(g_J = 1.2003340), # [3]
         }
 
         transitions = {


### PR DESCRIPTION
Not having the precise measured gJ value for the Ca40 metastable state introduces errors at the 10's of kHz level on the Ca 40 729 transition; afaik the best measured value is from [this PRL](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.102.023002), and I've added this to the Ca40 ion data in this commit.