### PR TITLE
fix release of new version and bump version to 2.0.0 due to breaking changes

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,7 +3,7 @@
 Change Log
 ==========
 
-v1.1
+v2.0.0
 ~~~~
 
 This version gives the ``atomic_physics`` API a much needed tidy up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "atomic_physics"
-version = "1.0.3"
+version = "2.0.0"
 description = "Nascent toolkit for calculating state energies, transition matrix elements, rate equations, obe solver, etc"
 authors = ["hartytp <thomas.peter.harty@gmail.com>"]
 


### PR DESCRIPTION
The version formerly known as v1.1 was not updated in the `pyproject.toml`. This Pr updates the `pyproject.toml` file to make the new release. Further, the new release makes breaking changes to the API. The release will therefore be marked as v2.0.0