### PR TITLE
Refactor atom definitions

### DIFF
--- a/atomic_physics/atoms/two_state.py
+++ b/atomic_physics/atoms/two_state.py
@@ -19,10 +19,10 @@ def field_for_frequency(frequency: float) -> float:
 
 
 class TwoStateAtomFactory(AtomFactory):
-    r"""``AtomFactory`` ideal spin 1/2 atoms.
+    r"""``AtomFactory`` for ideal spin 1/2 atoms.
 
     Attributes:
-        ground_level: the only level within the :class:`TwoStateAtom`.
+        ground_level: the only level within the :class:`TwoStateAtomFactory`.
         upper_state: index of the M=+1/2 (higher-energy) state.
         lower_state: index of the M=-1/2 (lower-energy) state.
     """

--- a/atomic_physics/atoms/two_state.py
+++ b/atomic_physics/atoms/two_state.py
@@ -18,18 +18,26 @@ def field_for_frequency(frequency: float) -> float:
     return B
 
 
-ground_level = Level(n=0, S=1 / 2, L=0, J=1 / 2)
-"""The only level within the :class:`TwoStateAtom`."""
+class TwoStateAtomFactory(AtomFactory):
+    r"""``AtomFactory`` ideal spin 1/2 atoms.
 
-upper_state = 0
-"""Index of the M=+1/2 (higher-energy) state. """
+    Attributes:
+        ground_level: the only level within the :class:`TwoStateAtom`.
+        upper_state: index of the M=+1/2 (higher-energy) state.
+        lower_state: index of the M=-1/2 (lower-energy) state.
+    """
 
-lower_state = 1
-"""Index of the M=-1/2 (lower-energy) state. """
+    ground_level: Level = Level(n=0, S=1 / 2, L=0, J=1 / 2)
+    upper_state = 0
+    lower_state = 1
 
-TwoStateAtom = AtomFactory(
-    nuclear_spin=0.0,
-    level_data=(LevelData(level=ground_level, Ahfs=0, Bhfs=0),),
-    transitions={},
-)
+    def __init__(self):
+        super().__init__(
+            nuclear_spin=0.0,
+            level_data=(LevelData(level=self.ground_level, Ahfs=0, Bhfs=0),),
+            transitions={},
+        )
+
+
+TwoStateAtom = TwoStateAtomFactory()
 """Ideal spin 1/2 atom with two states."""

--- a/atomic_physics/atoms/two_state.py
+++ b/atomic_physics/atoms/two_state.py
@@ -19,7 +19,7 @@ def field_for_frequency(frequency: float) -> float:
 
 
 class TwoStateAtomFactory(AtomFactory):
-    r"""``AtomFactory`` for ideal spin 1/2 atoms.
+    r""":class:`~atomic_physics.core.AtomFactory` for ideal spin 1/2 atoms.
 
     Attributes:
         ground_level: the only level within the :class:`TwoStateAtomFactory`.

--- a/atomic_physics/examples/M1_transitions.py
+++ b/atomic_physics/examples/M1_transitions.py
@@ -5,9 +5,7 @@ from atomic_physics.ions.ca43 import Ca43
 uB = consts.physical_constants["Bohr magneton"][0]
 
 
-ion = Ca43.filter_levels(level_filter=(Ca43.ground_level,))(
-    magnetic_field=146.0942e-4
-)
+ion = Ca43.filter_levels(level_filter=(Ca43.ground_level,))(magnetic_field=146.0942e-4)
 
 R = ion.get_magnetic_dipoles() / uB
 

--- a/atomic_physics/examples/M1_transitions.py
+++ b/atomic_physics/examples/M1_transitions.py
@@ -1,11 +1,11 @@
 import scipy.constants as consts
 
-from atomic_physics.ions import ca43
+from atomic_physics.ions.ca43 import Ca43
 
 uB = consts.physical_constants["Bohr magneton"][0]
 
 
-ion = ca43.Ca43.filter_levels(level_filter=(ca43.ground_level,))(
+ion = Ca43.filter_levels(level_filter=(Ca43.ground_level,))(
     magnetic_field=146.0942e-4
 )
 
@@ -13,10 +13,10 @@ R = ion.get_magnetic_dipoles() / uB
 
 for M3 in range(-3, +3 + 1):
     for q in [-1, 0, 1]:
-        F4 = ion.get_state_for_F(ca43.ground_level, F=4, M_F=M3 - q)
-        F3 = ion.get_state_for_F(ca43.ground_level, F=3, M_F=M3)
+        F4 = ion.get_state_for_F(Ca43.ground_level, F=4, M_F=M3 - q)
+        F3 = ion.get_state_for_F(Ca43.ground_level, F=3, M_F=M3)
         Rnm = R[
-            ion.get_state_for_F(ca43.ground_level, F=3, M_F=M3),
-            ion.get_state_for_F(ca43.ground_level, F=4, M_F=M3 - q),
+            ion.get_state_for_F(Ca43.ground_level, F=3, M_F=M3),
+            ion.get_state_for_F(Ca43.ground_level, F=4, M_F=M3 - q),
         ]
         print("Rnm for F=3, M={} -> F=4," "M={}: {:.6f}".format(M3, M3 - q, Rnm))

--- a/atomic_physics/examples/breit_rabi.py
+++ b/atomic_physics/examples/breit_rabi.py
@@ -3,9 +3,9 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from atomic_physics.ions import ca43
+from atomic_physics.ions.ca43 import Ca43
 
-Ca43 = ca43.Ca43.filter_levels(level_filter=(ca43.ground_level,))
+factory = Ca43.filter_levels(level_filter=(Ca43.ground_level,))
 idim = int(np.rint(2 * Ca43.nuclear_spin + 1))
 jdim = int(np.rint(2 * 1 / 2 + 1))
 
@@ -13,7 +13,7 @@ field_ax = np.arange(0.01, 30000, 200)  # B fields (Gauss)
 energies = np.zeros((len(field_ax), idim * jdim))
 
 for idx, magnetic_field in enumerate(field_ax):
-    ion = Ca43(magnetic_field * 1e-4)
+    ion = factory(magnetic_field * 1e-4)
     energies[idx, :] = ion.state_energies
 
 plt.figure()

--- a/atomic_physics/examples/ca_shelving.py
+++ b/atomic_physics/examples/ca_shelving.py
@@ -5,23 +5,23 @@ import numpy as np
 from scipy.linalg import expm
 
 from atomic_physics.core import Laser
-from atomic_physics.ions import ca43
+from atomic_physics.ions.ca43 import Ca43
 from atomic_physics.rate_equations import Rates
 
 t_ax = np.linspace(0, 100e-6, 100)  # Scan the duration of the "shelving" pulse
 intensity = 0.02  # 393 intensity
 
-ion = ca43.Ca43(magnetic_field=146e-4)
+ion = Ca43(magnetic_field=146e-4)
 
 # Ion starts in the F=4, M=+4 "stretched" state within the 4S1/2 ground-level
-stretch = ion.get_state_for_F(ca43.ground_level, F=4, M_F=+4)
+stretch = ion.get_state_for_F(Ca43.ground_level, F=4, M_F=+4)
 Vi = np.zeros((ion.num_states, 1))
 Vi[stretch] = 1
 
 # Tune the 393nm laser to resonance with the
 # 4S1/2(F=4, M_F=+4) <> 4P3/2(F=5, M_F=+5) transition
 detuning = ion.get_transition_frequency_for_states(
-    (stretch, ion.get_state_for_F(ca43.P32, F=5, M_F=+5))
+    (stretch, ion.get_state_for_F(Ca43.P32, F=5, M_F=+5))
 )
 lasers = (
     Laser("393", polarization=+1, intensity=intensity, detuning=detuning),
@@ -33,7 +33,7 @@ transitions = rates.get_transitions_matrix(lasers)
 shelved = np.zeros(len(t_ax))  # Population in the 3D5/2 level at the end
 for idx, t in np.ndenumerate(t_ax):
     Vf = expm(transitions * t) @ Vi  # NB use of matrix operations here!
-    shelved[idx] = np.sum(Vf[ion.get_slice_for_level(ca43.shelf)])
+    shelved[idx] = np.sum(Vf[ion.get_slice_for_level(Ca43.shelf)])
 
 plt.plot(t_ax * 1e6, shelved)
 plt.ylabel("Shelved Population")

--- a/atomic_physics/examples/clock_qubits.py
+++ b/atomic_physics/examples/clock_qubits.py
@@ -1,28 +1,28 @@
 import numpy as np
 
-import atomic_physics.ions.ca43 as ca43
+from atomic_physics.ions.ca43 import Ca43
 from atomic_physics.utils import d2f_dB2, field_insensitive_point
 
-Ca43 = ca43.Ca43.filter_levels(level_filter=(ca43.ground_level,))
+factory = Ca43.filter_levels(level_filter=(Ca43.ground_level,))
 
 print("Field-independent points:")
 for M3 in range(-3, +3 + 1):
     for q in [-1, 0, 1]:
         B0 = field_insensitive_point(
-            Ca43,
-            level_0=ca43.ground_level,
+            factory,
+            level_0=Ca43.ground_level,
             F_0=4,
             M_F_0=M3 - q,
-            level_1=ca43.ground_level,
+            level_1=Ca43.ground_level,
             F_1=3,
             M_F_1=M3,
         )
         if B0 is not None:
-            ion = Ca43(B0)
-            F4 = ion.get_state_for_F(ca43.ground_level, F=4, M_F=M3 - q)
-            F3 = ion.get_state_for_F(ca43.ground_level, F=3, M_F=M3)
+            ion = factory(B0)
+            F4 = ion.get_state_for_F(Ca43.ground_level, F=4, M_F=M3 - q)
+            F3 = ion.get_state_for_F(Ca43.ground_level, F=3, M_F=M3)
             f0 = ion.get_transition_frequency_for_states((F4, F3))
-            d2fdB2 = d2f_dB2(atom_factory=Ca43, magnetic_field=B0, states=(F4, F3))
+            d2fdB2 = d2f_dB2(atom_factory=factory, magnetic_field=B0, states=(F4, F3))
             print(
                 "4, {} --> 3, {}: {:.6f} GHz @ {:.5f} G ({:.3e} Hz/G^2)".format(
                     M3 - q,

--- a/atomic_physics/ions/ba133.py
+++ b/atomic_physics/ions/ba133.py
@@ -29,110 +29,114 @@ import scipy.constants as consts
 
 from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
-S12 = Level(n=6, S=1 / 2, L=0, J=1 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.
-"""
 
-P12 = Level(n=6, S=1 / 2, L=1, J=1 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=1, J=1/2\right>` level."""
+class Ba133Factory(AtomFactory):
+    r"""``AtomFactory`` for :math:`^{133}\mathrm{Ba}^+`.
 
-P32 = Level(n=6, S=1 / 2, L=1, J=3 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=1, J=3/2\right>` level."""
+    Attributes:
+        S12: the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.
+        P12: the :math:`\left|n=6, S=1/2, L=1, J=1/2\right>` level.
+        P32: the :math:`\left|n=6, S=1/2, L=1, J=3/2\right>` level.
+        D32: the :math:`\left|n=5, S=1/2, L=2, J=3/2\right>` level.
+        D52: the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` level.
+        ground_level: alias for the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` ground
+            level.
+        shelf: alias for the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` "shelf" level.
+    """
 
-D32 = Level(n=5, S=1 / 2, L=2, J=3 / 2)
-r""" The :math:`\left|n=5, S=1/2, L=2, J=3/2\right>` level."""
+    S12: Level = Level(n=6, S=1 / 2, L=0, J=1 / 2)
+    P12: Level = Level(n=6, S=1 / 2, L=1, J=1 / 2)
+    P32: Level = Level(n=6, S=1 / 2, L=1, J=3 / 2)
+    D32: Level = Level(n=5, S=1 / 2, L=2, J=3 / 2)
+    D52: Level = Level(n=5, S=1 / 2, L=2, J=5 / 2)
 
-D52 = Level(n=5, S=1 / 2, L=2, J=5 / 2)
-r""" The :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` level."""
+    ground_level: Level = S12
+    shelf: Level = D52
 
-ground_level = S12
-r""" Alias for the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` ground level of
-:math:`^{133}\mathrm{Ba}^+`.
-"""
+    def __init__(self):
+        level_data = (
+            LevelData(
+                level=self.ground_level,
+                Ahfs=-9925.45355459e6 * consts.h,  # [6]
+                Bhfs=0,
+                g_J=2.0024906,  # [5]
+                g_I=(2 / 1) * -0.77167,  # [4]
+            ),
+            LevelData(
+                level=self.P12,
+                Ahfs=-1840e6 * consts.h,  # [6]
+                Bhfs=0,
+                g_I=(2 / 1) * -0.77167,  # [4]
+            ),
+            LevelData(
+                level=self.P32,
+                Ahfs=-311.5e6 * consts.h,  # [7]
+                Bhfs=0,
+                g_I=(2 / 1) * -0.77167,  # [4]
+            ),
+            LevelData(
+                level=self.D32,
+                Ahfs=-468.5e6 * consts.h,  # [6]
+                Bhfs=0,
+                g_I=(2 / 1) * -0.77167,  # [4]
+            ),
+            LevelData(
+                level=self.D52,
+                Ahfs=83e6 * consts.h / 3,  # [7]
+                Bhfs=0,
+                g_I=(2 / 1) * -0.77167,  # [4]
+            ),
+        )
 
-shelf = D52
-r""" Alias for the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` "shelf" level of
-:math:`^{133}\mathrm{Ba}^+`.
-"""
+        transitions = {
+            "493": Transition(
+                lower=self.S12,
+                upper=self.P12,
+                einstein_A=9.53e7,  # [1]
+                frequency=2 * np.pi * 607426317511066.9,  # [1], [6]
+            ),
+            "455": Transition(
+                lower=self.S12,
+                upper=self.P32,
+                einstein_A=1.11e8,  # [1]
+                frequency=2 * np.pi * 658116515417261.1,  # [1], [7]
+            ),
+            "650": Transition(
+                lower=self.D32,
+                upper=self.P12,
+                einstein_A=3.1e7,  # [1]
+                frequency=2 * np.pi * 461311910410070.25,  # [1], [6]
+            ),
+            "585": Transition(
+                lower=self.D32,
+                upper=self.P32,
+                einstein_A=6.0e6,  # [1]
+                frequency=2 * np.pi * 512002108316264.5,
+            ),
+            "614": Transition(
+                lower=self.D52,
+                upper=self.P32,
+                einstein_A=4.12e7,  # [1]
+                frequency=2 * np.pi * 487990081496558.56,  # [1], [7]
+            ),
+            "1762": Transition(
+                lower=self.S12,
+                upper=self.D52,
+                einstein_A=1 / 30.14,  # [2]
+                frequency=2 * np.pi * 170126433920702.56,
+            ),
+            "2051": Transition(
+                lower=self.S12,
+                upper=self.D32,
+                einstein_A=12.5e-3,  # [3]
+                frequency=2 * np.pi * 146114407100996.62,
+            ),
+        }
 
-level_data = (
-    LevelData(
-        level=ground_level,
-        Ahfs=-9925.45355459e6 * consts.h,  # [6]
-        Bhfs=0,
-        g_J=2.0024906,  # [5]
-        g_I=(2 / 1) * -0.77167,  # [4]
-    ),
-    LevelData(
-        level=P12,
-        Ahfs=-1840e6 * consts.h,  # [6]
-        Bhfs=0,
-        g_I=(2 / 1) * -0.77167,  # [4]
-    ),
-    LevelData(
-        level=P32,
-        Ahfs=-311.5e6 * consts.h,  # [7]
-        Bhfs=0,
-        g_I=(2 / 1) * -0.77167,  # [4]
-    ),
-    LevelData(
-        level=D32,
-        Ahfs=-468.5e6 * consts.h,  # [6]
-        Bhfs=0,
-        g_I=(2 / 1) * -0.77167,  # [4]
-    ),
-    LevelData(
-        level=D52,
-        Ahfs=83e6 * consts.h / 3,  # [7]
-        Bhfs=0,
-        g_I=(2 / 1) * -0.77167,  # [4]
-    ),
-)
+        super().__init__(
+            nuclear_spin=1 / 2, level_data=level_data, transitions=transitions
+        )
 
-transitions = {
-    "493": Transition(
-        lower=S12,
-        upper=P12,
-        einstein_A=9.53e7,  # [1]
-        frequency=2 * np.pi * 607426317511066.9,  # [1], [6]
-    ),
-    "455": Transition(
-        lower=S12,
-        upper=P32,
-        einstein_A=1.11e8,  # [1]
-        frequency=2 * np.pi * 658116515417261.1,  # [1], [7]
-    ),
-    "650": Transition(
-        lower=D32,
-        upper=P12,
-        einstein_A=3.1e7,  # [1]
-        frequency=2 * np.pi * 461311910410070.25,  # [1], [6]
-    ),
-    "585": Transition(
-        lower=D32,
-        upper=P32,
-        einstein_A=6.0e6,  # [1]
-        frequency=2 * np.pi * 512002108316264.5,
-    ),
-    "614": Transition(
-        lower=D52,
-        upper=P32,
-        einstein_A=4.12e7,  # [1]
-        frequency=2 * np.pi * 487990081496558.56,  # [1], [7]
-    ),
-    "1762": Transition(
-        lower=S12,
-        upper=D52,
-        einstein_A=1 / 30.14,  # [2]
-        frequency=2 * np.pi * 170126433920702.56,
-    ),
-    "2051": Transition(
-        lower=S12,
-        upper=D32,
-        einstein_A=12.5e-3,  # [3]
-        frequency=2 * np.pi * 146114407100996.62,
-    ),
-}
 
-Ba133 = AtomFactory(nuclear_spin=1 / 2, level_data=level_data, transitions=transitions)
+Ba133 = Ba133Factory()
 r""" :math:`^{133}\mathrm{Ba}^+` atomic structure. """

--- a/atomic_physics/ions/ba133.py
+++ b/atomic_physics/ions/ba133.py
@@ -31,7 +31,7 @@ from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
 
 class Ba133Factory(AtomFactory):
-    r"""``AtomFactory`` for :math:`^{133}\mathrm{Ba}^+`.
+    r""":class:`~atomic_physics.core.AtomFactory` for :math:`^{133}\mathrm{Ba}^+`.
 
     Attributes:
         S12: the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -33,111 +33,114 @@ import scipy.constants as consts
 
 from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
-S12 = Level(n=6, S=1 / 2, L=0, J=1 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.
-"""
 
-P12 = Level(n=6, S=1 / 2, L=1, J=1 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=1, J=1/2\right>` level."""
+class Ba135Factory(AtomFactory):
+    r"""``AtomFactory`` for :math:`^{135}\mathrm{Ba}^+`.
 
-P32 = Level(n=6, S=1 / 2, L=1, J=3 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=1, J=3/2\right>` level."""
+    Attributes:
+        S12: the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.
+        P12: the :math:`\left|n=6, S=1/2, L=1, J=1/2\right>` level.
+        P32: the :math:`\left|n=6, S=1/2, L=1, J=3/2\right>` level.
+        D32: the :math:`\left|n=5, S=1/2, L=2, J=3/2\right>` level.
+        D52: the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` level.
+        ground_level: alias for the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` ground
+            level.
+        shelf: alias for the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` "shelf" level.
+    """
 
-D32 = Level(n=5, S=1 / 2, L=2, J=3 / 2)
-r""" The :math:`\left|n=5, S=1/2, L=2, J=3/2\right>` level."""
+    S12: Level = Level(n=6, S=1 / 2, L=0, J=1 / 2)
+    P12: Level = Level(n=6, S=1 / 2, L=1, J=1 / 2)
+    P32: Level = Level(n=6, S=1 / 2, L=1, J=3 / 2)
+    D32: Level = Level(n=5, S=1 / 2, L=2, J=3 / 2)
+    D52: Level = Level(n=5, S=1 / 2, L=2, J=5 / 2)
 
-D52 = Level(n=5, S=1 / 2, L=2, J=5 / 2)
-r""" The :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` level."""
+    ground_level: Level = S12
+    shelf: Level = D52
 
-ground_level = S12
-r""" Alias for the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` ground level of
-:math:`^{135}\mathrm{Ba}^+`.
-"""
+    def __init__(self):
+        level_data = (
+            LevelData(
+                level=self.ground_level,
+                Ahfs=3591.67011745e6 * consts.h,  # [6]
+                Bhfs=0,
+                g_J=2.0024906,  # [5]
+                g_I=(2 / 3) * 0.83794,  # [4]
+            ),
+            LevelData(
+                level=self.P12,
+                Ahfs=664.6e6 * consts.h,  # [7]
+                Bhfs=0,
+                g_I=(2 / 3) * 0.83794,  # [4]
+            ),
+            LevelData(
+                level=self.P32,
+                Ahfs=113.0e6 * consts.h,  # [7]
+                Bhfs=59.0e6 * consts.h,  # [7]
+                g_I=(2 / 3) * 0.83794,  # [4]
+            ),
+            LevelData(
+                level=self.D32,
+                Ahfs=169.5898e6 * consts.h,  # [8]
+                Bhfs=28.9528 * consts.h,  # [8]
+                g_I=(2 / 3) * 0.83794,  # [4]
+            ),
+            LevelData(
+                level=self.D52,
+                Ahfs=-10.735e6 * consts.h,  # [8]
+                Bhfs=38.692e6 * consts.h,  # [8]
+                g_I=(2 / 3) * 0.83794,  # [4]
+            ),
+        )
 
-shelf = D52
-r""" Alias for the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` "shelf" level of
-:math:`^{135}\mathrm{Ba}^+`.
-"""
+        transitions = {
+            "493": Transition(
+                lower=self.S12,
+                upper=self.P12,
+                einstein_A=9.53e7,  # [1]
+                frequency=2 * np.pi * 607426317511042.5,  # [1], [9]
+            ),
+            "455": Transition(
+                lower=self.S12,
+                upper=self.P32,
+                einstein_A=1.11e8,  # [1]
+                frequency=2 * np.pi * 658116515417266.0,
+            ),
+            "650": Transition(
+                lower=self.D32,
+                upper=self.P12,
+                einstein_A=3.1e7,  # [1]
+                frequency=2 * np.pi * 461311910409954.94,  # [1], [7]
+            ),
+            "585": Transition(
+                lower=self.D32,
+                upper=self.P32,
+                einstein_A=6.0e6,  # [1]
+                frequency=2 * np.pi * 512002108316178.56,  # [1], [7]
+            ),
+            "614": Transition(
+                lower=self.D52,
+                upper=self.P32,
+                einstein_A=4.12e7,  # [1]
+                frequency=2 * np.pi * 487990081496443.94,  # [1], [7]
+            ),
+            "1762": Transition(
+                lower=self.S12,
+                upper=self.D52,
+                einstein_A=1 / 30.14,  # [2]
+                frequency=2 * np.pi * 170126433920822.06,
+            ),
+            "2051": Transition(
+                lower=self.S12,
+                upper=self.D32,
+                einstein_A=12.5e-3,  # [3]
+                frequency=2 * np.pi * 146114407101087.56,
+            ),
+        }
+
+        super().__init__(
+            nuclear_spin=3 / 2, level_data=level_data, transitions=transitions
+        )
 
 
-level_data = (
-    LevelData(
-        level=ground_level,
-        Ahfs=3591.67011745e6 * consts.h,  # [6]
-        Bhfs=0,
-        g_J=2.0024906,  # [5]
-        g_I=(2 / 3) * 0.83794,  # [4]
-    ),
-    LevelData(
-        level=P12,
-        Ahfs=664.6e6 * consts.h,  # [7]
-        Bhfs=0,
-        g_I=(2 / 3) * 0.83794,  # [4]
-    ),
-    LevelData(
-        level=P32,
-        Ahfs=113.0e6 * consts.h,  # [7]
-        Bhfs=59.0e6 * consts.h,  # [7]
-        g_I=(2 / 3) * 0.83794,  # [4]
-    ),
-    LevelData(
-        level=D32,
-        Ahfs=169.5898e6 * consts.h,  # [8]
-        Bhfs=28.9528 * consts.h,  # [8]
-        g_I=(2 / 3) * 0.83794,  # [4]
-    ),
-    LevelData(
-        level=D52,
-        Ahfs=-10.735e6 * consts.h,  # [8]
-        Bhfs=38.692e6 * consts.h,  # [8]
-        g_I=(2 / 3) * 0.83794,  # [4]
-    ),
-)
-
-transitions = {
-    "493": Transition(
-        lower=S12,
-        upper=P12,
-        einstein_A=9.53e7,  # [1]
-        frequency=2 * np.pi * 607426317511042.5,  # [1], [9]
-    ),
-    "455": Transition(
-        lower=S12,
-        upper=P32,
-        einstein_A=1.11e8,  # [1]
-        frequency=2 * np.pi * 658116515417266.0,
-    ),
-    "650": Transition(
-        lower=D32,
-        upper=P12,
-        einstein_A=3.1e7,  # [1]
-        frequency=2 * np.pi * 461311910409954.94,  # [1], [7]
-    ),
-    "585": Transition(
-        lower=D32,
-        upper=P32,
-        einstein_A=6.0e6,  # [1]
-        frequency=2 * np.pi * 512002108316178.56,  # [1], [7]
-    ),
-    "614": Transition(
-        lower=D52,
-        upper=P32,
-        einstein_A=4.12e7,  # [1]
-        frequency=2 * np.pi * 487990081496443.94,  # [1], [7]
-    ),
-    "1762": Transition(
-        lower=S12,
-        upper=D52,
-        einstein_A=1 / 30.14,  # [2]
-        frequency=2 * np.pi * 170126433920822.06,
-    ),
-    "2051": Transition(
-        lower=S12,
-        upper=D32,
-        einstein_A=12.5e-3,  # [3]
-        frequency=2 * np.pi * 146114407101087.56,
-    ),
-}
-
-Ba135 = AtomFactory(nuclear_spin=3 / 2, level_data=level_data, transitions=transitions)
+Ba135 = Ba135Factory()
 r""" :math:`^{135}\mathrm{Ba}^+` atomic structure. """

--- a/atomic_physics/ions/ba135.py
+++ b/atomic_physics/ions/ba135.py
@@ -35,7 +35,7 @@ from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
 
 class Ba135Factory(AtomFactory):
-    r"""``AtomFactory`` for :math:`^{135}\mathrm{Ba}^+`.
+    r""":class:`~atomic_physics.core.AtomFactory` for :math:`^{135}\mathrm{Ba}^+`.
 
     Attributes:
         S12: the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -34,111 +34,114 @@ import scipy.constants as consts
 
 from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
-S12 = Level(n=6, S=1 / 2, L=0, J=1 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.
-"""
 
-P12 = Level(n=6, S=1 / 2, L=1, J=1 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=1, J=1/2\right>` level."""
+class Ba137Factory(AtomFactory):
+    r"""``AtomFactory`` for :math:`^{137}\mathrm{Ba}^+`.
 
-P32 = Level(n=6, S=1 / 2, L=1, J=3 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=1, J=3/2\right>` level."""
+    Attributes:
+        S12: the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.
+        P12: the :math:`\left|n=6, S=1/2, L=1, J=1/2\right>` level.
+        P32: the :math:`\left|n=6, S=1/2, L=1, J=3/2\right>` level.
+        D32: the :math:`\left|n=5, S=1/2, L=2, J=3/2\right>` level.
+        D52: the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` level.
+        ground_level: alias for the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` ground
+            level.
+        shelf: alias for the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` "shelf" level.
+    """
 
-D32 = Level(n=5, S=1 / 2, L=2, J=3 / 2)
-r""" The :math:`\left|n=5, S=1/2, L=2, J=3/2\right>` level."""
+    S12: Level = Level(n=6, S=1 / 2, L=0, J=1 / 2)
+    P12: Level = Level(n=6, S=1 / 2, L=1, J=1 / 2)
+    P32: Level = Level(n=6, S=1 / 2, L=1, J=3 / 2)
+    D32: Level = Level(n=5, S=1 / 2, L=2, J=3 / 2)
+    D52: Level = Level(n=5, S=1 / 2, L=2, J=5 / 2)
 
-D52 = Level(n=5, S=1 / 2, L=2, J=5 / 2)
-r""" The :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` level."""
+    ground_level: Level = S12
+    shelf: Level = D52
 
-ground_level = S12
-r""" Alias for the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` ground level of
-:math:`^{137}\mathrm{Ba}^+`.
-"""
+    def __init__(self):
+        level_data = (
+            LevelData(
+                level=self.S12,
+                Ahfs=4018.87083384e6 * consts.h,  # [6]
+                Bhfs=0,
+                g_J=2.0024906,  # [5]
+                g_I=(2 / 3) * 0.93737,  # [4]
+            ),
+            LevelData(
+                level=self.P12,
+                Ahfs=743.7e6 * consts.h,  # [7]
+                Bhfs=0,
+                g_I=(2 / 3) * 0.93737,  # [4]
+            ),
+            LevelData(
+                level=self.P32,
+                Ahfs=127.2e6 * consts.h,  # [7]
+                Bhfs=92.5e6 * consts.h,  # [7]
+                g_I=(2 / 3) * 0.93737,  # [4]
+            ),
+            LevelData(
+                level=self.D32,
+                Ahfs=189.731101e6 * consts.h,  # [8]
+                Bhfs=44.536612e6 * consts.h,  # [8]
+                g_I=(2 / 3) * 0.93737,  # [4]
+            ),
+            LevelData(
+                level=self.D52,
+                Ahfs=-12.029234e6 * consts.h,  # [9]
+                Bhfs=59.52552e6 * consts.h,  # [9]
+                g_I=(2 / 3) * 0.93737,  # [4]
+            ),
+        )
 
-shelf = D52
-r""" Alias for the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` "shelf" level of
-:math:`^{137}\mathrm{Ba}^+`.
-"""
+        transitions = {
+            "493": Transition(
+                lower=self.S12,
+                upper=self.P12,
+                einstein_A=9.53e7,  # [1]
+                frequency=2 * np.pi * 607426317510965.0,  # [1], [10]
+            ),
+            "455": Transition(
+                lower=self.S12,
+                upper=self.P32,
+                einstein_A=1.11e8,  # [1]
+                frequency=2 * np.pi * 658116515417166.6,
+            ),
+            "650": Transition(
+                lower=self.D32,
+                upper=self.P12,
+                einstein_A=3.1e7,  # [1]
+                frequency=2 * np.pi * 461311910409885.25,  # [1], [7]
+            ),
+            "585": Transition(
+                lower=self.D32,
+                upper=self.P32,
+                einstein_A=6.0e6,  # [1]
+                frequency=2 * np.pi * 512002108316086.9,  # [1], [7]
+            ),
+            "614": Transition(
+                lower=self.D52,
+                upper=self.P32,
+                einstein_A=4.12e7,  # [1]
+                frequency=2 * np.pi * 487990081496344.9,  # [1], [7]
+            ),
+            "1762": Transition(
+                lower=self.S12,
+                upper=self.D52,
+                einstein_A=1 / 30.14,  # [2]
+                frequency=2 * np.pi * 170126433920821.75,
+            ),
+            "2051": Transition(
+                lower=self.S12,
+                upper=self.D32,
+                einstein_A=12.5e-3,  # [3]
+                frequency=2 * np.pi * 146114407101079.75,
+            ),
+        }
+
+        super().__init__(
+            nuclear_spin=3 / 2, level_data=level_data, transitions=transitions
+        )
 
 
-level_data = (
-    LevelData(
-        level=ground_level,
-        Ahfs=4018.87083384e6 * consts.h,  # [6]
-        Bhfs=0,
-        g_J=2.0024906,  # [5]
-        g_I=(2 / 3) * 0.93737,  # [4]
-    ),
-    LevelData(
-        level=P12,
-        Ahfs=743.7e6 * consts.h,  # [7]
-        Bhfs=0,
-        g_I=(2 / 3) * 0.93737,  # [4]
-    ),
-    LevelData(
-        level=P32,
-        Ahfs=127.2e6 * consts.h,  # [7]
-        Bhfs=92.5e6 * consts.h,  # [7]
-        g_I=(2 / 3) * 0.93737,  # [4]
-    ),
-    LevelData(
-        level=D32,
-        Ahfs=189.731101e6 * consts.h,  # [8]
-        Bhfs=44.536612e6 * consts.h,  # [8]
-        g_I=(2 / 3) * 0.93737,  # [4]
-    ),
-    LevelData(
-        level=D52,
-        Ahfs=-12.029234e6 * consts.h,  # [9]
-        Bhfs=59.52552e6 * consts.h,  # [9]
-        g_I=(2 / 3) * 0.93737,  # [4]
-    ),
-)
-
-transitions = {
-    "493": Transition(
-        lower=S12,
-        upper=P12,
-        einstein_A=9.53e7,  # [1]
-        frequency=2 * np.pi * 607426317510965.0,  # [1], [10]
-    ),
-    "455": Transition(
-        lower=S12,
-        upper=P32,
-        einstein_A=1.11e8,  # [1]
-        frequency=2 * np.pi * 658116515417166.6,
-    ),
-    "650": Transition(
-        lower=D32,
-        upper=P12,
-        einstein_A=3.1e7,  # [1]
-        frequency=2 * np.pi * 461311910409885.25,  # [1], [7]
-    ),
-    "585": Transition(
-        lower=D32,
-        upper=P32,
-        einstein_A=6.0e6,  # [1]
-        frequency=2 * np.pi * 512002108316086.9,  # [1], [7]
-    ),
-    "614": Transition(
-        lower=D52,
-        upper=P32,
-        einstein_A=4.12e7,  # [1]
-        frequency=2 * np.pi * 487990081496344.9,  # [1], [7]
-    ),
-    "1762": Transition(
-        lower=S12,
-        upper=D52,
-        einstein_A=1 / 30.14,  # [2]
-        frequency=2 * np.pi * 170126433920821.75,
-    ),
-    "2051": Transition(
-        lower=S12,
-        upper=D32,
-        einstein_A=12.5e-3,  # [3]
-        frequency=2 * np.pi * 146114407101079.75,
-    ),
-}
-
-Ba137 = AtomFactory(nuclear_spin=3 / 2, level_data=level_data, transitions=transitions)
+Ba137 = Ba137Factory()
 r""" :math:`^{137}\mathrm{Ba}^+` atomic structure. """

--- a/atomic_physics/ions/ba137.py
+++ b/atomic_physics/ions/ba137.py
@@ -36,7 +36,7 @@ from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
 
 class Ba137Factory(AtomFactory):
-    r"""``AtomFactory`` for :math:`^{137}\mathrm{Ba}^+`.
+    r""":class:`~atomic_physics.core.AtomFactory` for :math:`^{137}\mathrm{Ba}^+`.
 
     Attributes:
         S12: the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.

--- a/atomic_physics/ions/ba138.py
+++ b/atomic_physics/ions/ba138.py
@@ -20,7 +20,7 @@ from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
 
 class Ba138Factory(AtomFactory):
-    r"""``AtomFactory`` for :math:`^{138}\mathrm{Ba}^+`.
+    r""":class:`~atomic_physics.core.AtomFactory` for :math:`^{138}\mathrm{Ba}^+`.
 
     Attributes:
         S12: the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.

--- a/atomic_physics/ions/ba138.py
+++ b/atomic_physics/ions/ba138.py
@@ -18,85 +18,88 @@ import numpy as np
 
 from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
-S12 = Level(n=6, S=1 / 2, L=0, J=1 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.
-"""
 
-P12 = Level(n=6, S=1 / 2, L=1, J=1 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=1, J=1/2\right>` level."""
+class Ba138Factory(AtomFactory):
+    r"""``AtomFactory`` for :math:`^{138}\mathrm{Ba}^+`.
 
-P32 = Level(n=6, S=1 / 2, L=1, J=3 / 2)
-r""" The :math:`\left|n=6, S=1/2, L=1, J=3/2\right>` level."""
+    Attributes:
+        S12: the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` level.
+        P12: the :math:`\left|n=6, S=1/2, L=1, J=1/2\right>` level.
+        P32: the :math:`\left|n=6, S=1/2, L=1, J=3/2\right>` level.
+        D32: the :math:`\left|n=5, S=1/2, L=2, J=3/2\right>` level.
+        D52: the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` level.
+        ground_level: alias for the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` ground
+            level.
+        shelf: alias for the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` "shelf" level.
+    """
 
-D32 = Level(n=5, S=1 / 2, L=2, J=3 / 2)
-r""" The :math:`\left|n=5, S=1/2, L=2, J=3/2\right>` level."""
+    S12: Level = Level(n=6, S=1 / 2, L=0, J=1 / 2)
+    P12: Level = Level(n=6, S=1 / 2, L=1, J=1 / 2)
+    P32: Level = Level(n=6, S=1 / 2, L=1, J=3 / 2)
+    D32: Level = Level(n=5, S=1 / 2, L=2, J=3 / 2)
+    D52: Level = Level(n=5, S=1 / 2, L=2, J=5 / 2)
 
-D52 = Level(n=5, S=1 / 2, L=2, J=5 / 2)
-r""" The :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` level."""
+    ground_level: Level = S12
+    shelf: Level = D52
 
-ground_level = S12
-r""" Alias for the :math:`\left|n=6, S=1/2, L=0, J=1/2\right>` ground level of
-:math:`^{138}\mathrm{Ba}^+`.
-"""
+    def __init__(self):
+        level_data = (
+            LevelData(level=self.S12, Ahfs=0, Bhfs=0),
+            LevelData(level=self.P12, Ahfs=0, Bhfs=0),
+            LevelData(level=self.P32, Ahfs=0, Bhfs=0),
+            LevelData(level=self.D32, Ahfs=0, Bhfs=0),
+            LevelData(level=self.D52, Ahfs=0, Bhfs=0),
+        )
 
-shelf = D52
-r""" Alias for the :math:`\left|n=5, S=1/2, L=2, J=5/2\right>` "shelf" level of
-:math:`^{138}\mathrm{Ba}^+`.
-"""
+        transitions = {
+            "493": Transition(
+                lower=self.S12,
+                upper=self.P12,
+                einstein_A=9.53e7,  # [1]
+                frequency=2 * np.pi * 607426317510693.9,  # [1]
+            ),
+            "455": Transition(
+                lower=self.S12,
+                upper=self.P32,
+                einstein_A=1.11e8,  # [1]
+                frequency=2 * np.pi * 658116515416903.1,  # [1]
+            ),
+            "650": Transition(
+                lower=self.D32,
+                upper=self.P12,
+                einstein_A=3.1e7,  # [1]
+                frequency=2 * np.pi * 461311910409872.25,  # [1]
+            ),
+            "585": Transition(
+                lower=self.D32,
+                upper=self.P32,
+                einstein_A=6.0e6,  # [1]
+                frequency=2 * np.pi * 512002108316081.56,  # [1]
+            ),
+            "614": Transition(
+                lower=self.D52,
+                upper=self.P32,
+                einstein_A=4.12e7,  # [1]
+                frequency=2 * np.pi * 487990081496342.56,  # [1]
+            ),
+            "1762": Transition(
+                lower=self.S12,
+                upper=self.D52,
+                einstein_A=1 / 30.14,  # [2]
+                frequency=2 * np.pi * 170126433920560.6,
+            ),
+            "2051": Transition(
+                lower=self.S12,
+                upper=self.D32,
+                einstein_A=12.5e-3,  # [3]
+                frequency=2 * np.pi * 146114407100821.62,
+            ),
+        }
+
+        super().__init__(
+            nuclear_spin=0.0, level_data=level_data, transitions=transitions
+        )
 
 
-level_data = (
-    LevelData(level=ground_level, Ahfs=0, Bhfs=0),
-    LevelData(level=P12, Ahfs=0, Bhfs=0),
-    LevelData(level=P32, Ahfs=0, Bhfs=0),
-    LevelData(level=D32, Ahfs=0, Bhfs=0),
-    LevelData(level=D52, Ahfs=0, Bhfs=0),
-)
-
-transitions = {
-    "493": Transition(
-        lower=S12,
-        upper=P12,
-        einstein_A=9.53e7,  # [1]
-        frequency=2 * np.pi * 607426317510693.9,  # [1]
-    ),
-    "455": Transition(
-        lower=S12,
-        upper=P32,
-        einstein_A=1.11e8,  # [1]
-        frequency=2 * np.pi * 658116515416903.1,  # [1]
-    ),
-    "650": Transition(
-        lower=D32,
-        upper=P12,
-        einstein_A=3.1e7,  # [1]
-        frequency=2 * np.pi * 461311910409872.25,  # [1]
-    ),
-    "585": Transition(
-        lower=D32,
-        upper=P32,
-        einstein_A=6.0e6,  # [1]
-        frequency=2 * np.pi * 512002108316081.56,  # [1]
-    ),
-    "614": Transition(
-        lower=D52,
-        upper=P32,
-        einstein_A=4.12e7,  # [1]
-        frequency=2 * np.pi * 487990081496342.56,  # [1]
-    ),
-    "1762": Transition(
-        lower=S12,
-        upper=D52,
-        einstein_A=1 / 30.14,  # [2]
-        frequency=2 * np.pi * 170126433920560.6,
-    ),
-    "2051": Transition(
-        lower=S12,
-        upper=D32,
-        einstein_A=12.5e-3,  # [3]
-        frequency=2 * np.pi * 146114407100821.62,
-    ),
-}
-
-Ba138 = AtomFactory(nuclear_spin=0.0, level_data=level_data, transitions=transitions)
+Ba138 = Ba138Factory()
 r""" :math:`^{138}\mathrm{Ba}^+` atomic structure. """

--- a/atomic_physics/ions/ca40.py
+++ b/atomic_physics/ions/ca40.py
@@ -20,85 +20,87 @@ D32 = Level
 shelf = D52 = Level
 
 
-S12 = Level(n=4, S=1 / 2, L=0, J=1 / 2)
-r""" The :math:`\left|n=4, S=1/2, L=0, J=1/2\right>` level.
-"""
+class Ca40Factory(AtomFactory):
+    r"""``AtomFactory`` for :math:`^{40}\mathrm{Ca}^+`.
 
-P12 = Level(n=4, S=1 / 2, L=1, J=1 / 2)
-r""" The :math:`\left|n=4, S=1/2, L=1, J=1/2\right>` level."""
+    Attributes:
+        S12: the :math:`\left|n=4, S=1/2, L=0, J=1/2\right>` level.
+        P12: the :math:`\left|n=4, S=1/2, L=1, J=1/2\right>` level.
+        P32: the :math:`\left|n=4, S=1/2, L=1, J=3/2\right>` level.
+        D32: the :math:`\left|n=3, S=1/2, L=2, J=3/2\right>` level.
+        D52: the :math:`\left|n=3, S=1/2, L=2, J=5/2\right>` level.
+        ground_level: alias for the :math:`\left|n=4, S=1/2, L=0, J=1/2\right>` ground
+            level.
+        shelf: alias for the :math:`\left|n=3, S=1/2, L=2, J=5/2\right>` "shelf" level.
+    """
 
-P32 = Level(n=4, S=1 / 2, L=1, J=3 / 2)
-r""" The :math:`\left|n=4, S=1/2, L=1, J=3/2\right>` level."""
+    S12: Level = Level(n=4, S=1 / 2, L=0, J=1 / 2)
+    P12: Level = Level(n=4, S=1 / 2, L=1, J=1 / 2)
+    P32: Level = Level(n=4, S=1 / 2, L=1, J=3 / 2)
+    D32: Level = Level(n=3, S=1 / 2, L=2, J=3 / 2)
+    D52: Level = Level(n=3, S=1 / 2, L=2, J=5 / 2)
 
-D32 = Level(n=3, S=1 / 2, L=2, J=3 / 2)
-r""" The :math:`\left|n=3, S=1/2, L=2, J=3/2\right>` level."""
+    ground_level: Level = S12
+    shelf: Level = D52
 
-D52 = Level(n=3, S=1 / 2, L=2, J=5 / 2)
-r""" The :math:`\left|n=3, S=1/2, L=2, J=5/2\right>` level."""
+    def __init__(self):
+        level_data = (
+            LevelData(level=self.S12, g_J=2.00225664, Ahfs=0, Bhfs=0),  # [2]
+            LevelData(level=self.P12, Ahfs=0, Bhfs=0),
+            LevelData(level=self.P32, Ahfs=0, Bhfs=0),
+            LevelData(level=self.D32, Ahfs=0, Bhfs=0),
+            LevelData(level=self.D52, g_J=1.2003340, Ahfs=0, Bhfs=0),  # [3]
+        )
 
-ground_level = S12
-r""" Alias for the :math:`\left|n=4, S=1/2, L=0, J=1/2\right>` ground level of
-:math:`^{40}\mathrm{Ca}^+`.
-"""
+        transitions = {
+            "397": Transition(
+                lower=self.S12,
+                upper=self.P12,
+                einstein_A=132e6,  # [?]
+                frequency=2 * np.pi * 755222765771e3,  # [1]
+            ),
+            "393": Transition(
+                lower=self.S12,
+                upper=self.P32,
+                einstein_A=135e6,  # [?]
+                frequency=2 * np.pi * 761905012599e3,  # [1]
+            ),
+            "866": Transition(
+                lower=self.D32,
+                upper=self.P12,
+                einstein_A=8.4e6,  # [?]
+                frequency=2 * np.pi * 346000235016e3,  # [1]
+            ),
+            "850": Transition(
+                lower=self.D32,
+                upper=self.P32,
+                einstein_A=0.955e6,  # [?]
+                frequency=2 * np.pi * 352682481844e3,  # [1]
+            ),
+            "854": Transition(
+                lower=self.D52,
+                upper=self.P32,
+                einstein_A=8.48e6,  # [?]
+                frequency=2 * np.pi * 350862882823e3,  # [1]
+            ),
+            "729": Transition(
+                lower=self.S12,
+                upper=self.D52,
+                einstein_A=0.856,  # [?]
+                frequency=411042129776.4017e3 * 2 * np.pi,  # [1]
+            ),
+            "733": Transition(
+                lower=self.S12,
+                upper=self.D32,
+                einstein_A=0.850,  # [?]
+                frequency=409222530754.868e3 * 2 * np.pi,  # [1]
+            ),
+        }
 
-shelf = D52
-r""" Alias for the :math:`\left|n=3, S=1/2, L=2, J=5/2\right>` "shelf" level of
-:math:`^{40}\mathrm{Ca}^+`.
-"""
+        super().__init__(
+            nuclear_spin=0.0, level_data=level_data, transitions=transitions
+        )
 
 
-level_data = (
-    LevelData(level=ground_level, g_J=2.00225664, Ahfs=0, Bhfs=0),  # [2]
-    LevelData(level=P12, Ahfs=0, Bhfs=0),
-    LevelData(level=P32, Ahfs=0, Bhfs=0),
-    LevelData(level=D32, Ahfs=0, Bhfs=0),
-    LevelData(level=D52, g_J=1.2003340, Ahfs=0, Bhfs=0),  # [3]
-)
-
-transitions = {
-    "397": Transition(
-        lower=S12,
-        upper=P12,
-        einstein_A=132e6,  # [?]
-        frequency=2 * np.pi * 755222765771e3,  # [1]
-    ),
-    "393": Transition(
-        lower=S12,
-        upper=P32,
-        einstein_A=135e6,  # [?]
-        frequency=2 * np.pi * 761905012599e3,  # [1]
-    ),
-    "866": Transition(
-        lower=D32,
-        upper=P12,
-        einstein_A=8.4e6,  # [?]
-        frequency=2 * np.pi * 346000235016e3,  # [1]
-    ),
-    "850": Transition(
-        lower=D32,
-        upper=P32,
-        einstein_A=0.955e6,  # [?]
-        frequency=2 * np.pi * 352682481844e3,  # [1]
-    ),
-    "854": Transition(
-        lower=D52,
-        upper=P32,
-        einstein_A=8.48e6,  # [?]
-        frequency=2 * np.pi * 350862882823e3,  # [1]
-    ),
-    "729": Transition(
-        lower=S12,
-        upper=D52,
-        einstein_A=0.856,  # [?]
-        frequency=411042129776.4017e3 * 2 * np.pi,  # [1]
-    ),
-    "733": Transition(
-        lower=S12,
-        upper=D32,
-        einstein_A=0.850,  # [?]
-        frequency=409222530754.868e3 * 2 * np.pi,  # [1]
-    ),
-}
-
-Ca40 = AtomFactory(nuclear_spin=0.0, level_data=level_data, transitions=transitions)
+Ca40 = Ca40Factory()
 r""" :math:`^{40}\mathrm{Ca}^+` atomic structure. """

--- a/atomic_physics/ions/ca40.py
+++ b/atomic_physics/ions/ca40.py
@@ -21,7 +21,7 @@ shelf = D52 = Level
 
 
 class Ca40Factory(AtomFactory):
-    r"""``AtomFactory`` for :math:`^{40}\mathrm{Ca}^+`.
+    r""":class:`~atomic_physics.core.AtomFactory` for :math:`^{40}\mathrm{Ca}^+`.
 
     Attributes:
         S12: the :math:`\left|n=4, S=1/2, L=0, J=1/2\right>` level.

--- a/atomic_physics/ions/ca43.py
+++ b/atomic_physics/ions/ca43.py
@@ -17,112 +17,115 @@ import scipy.constants as consts
 
 from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
-S12 = Level(n=4, S=1 / 2, L=0, J=1 / 2)
-r""" The :math:`\left|n=4, S=1/2, L=0, J=1/2\right>` level.
-"""
 
-P12 = Level(n=4, S=1 / 2, L=1, J=1 / 2)
-r""" The :math:`\left|n=4, S=1/2, L=1, J=1/2\right>` level."""
+class Ca43Factory(AtomFactory):
+    r"""``AtomFactory`` for :math:`^{43}\mathrm{Ca}^+`.
 
-P32 = Level(n=4, S=1 / 2, L=1, J=3 / 2)
-r""" The :math:`\left|n=4, S=1/2, L=1, J=3/2\right>` level."""
+    Attributes:
+        S12: the :math:`\left|n=4, S=1/2, L=0, J=1/2\right>` level.
+        P12: the :math:`\left|n=4, S=1/2, L=1, J=1/2\right>` level.
+        P32: the :math:`\left|n=4, S=1/2, L=1, J=3/2\right>` level.
+        D32: the :math:`\left|n=3, S=1/2, L=2, J=3/2\right>` level.
+        D52: the :math:`\left|n=3, S=1/2, L=2, J=5/2\right>` level.
+        ground_level: alias for the :math:`\left|n=4, S=1/2, L=0, J=1/2\right>` ground
+            level.
+        shelf: alias for the :math:`\left|n=3, S=1/2, L=2, J=5/2\right>` "shelf" level.
+    """
 
-D32 = Level(n=3, S=1 / 2, L=2, J=3 / 2)
-r""" The :math:`\left|n=3, S=1/2, L=2, J=3/2\right>` level."""
+    S12: Level = Level(n=4, S=1 / 2, L=0, J=1 / 2)
+    P12: Level = Level(n=4, S=1 / 2, L=1, J=1 / 2)
+    P32: Level = Level(n=4, S=1 / 2, L=1, J=3 / 2)
+    D32: Level = Level(n=3, S=1 / 2, L=2, J=3 / 2)
+    D52: Level = Level(n=3, S=1 / 2, L=2, J=5 / 2)
 
-D52 = Level(n=3, S=1 / 2, L=2, J=5 / 2)
-r""" The :math:`\left|n=3, S=1/2, L=2, J=5/2\right>` level."""
+    ground_level: Level = S12
+    shelf: Level = D52
 
-ground_level = S12
-r""" Alias for the :math:`\left|n=4, S=1/2, L=0, J=1/2\right>` ground level of
-:math:`^{43}\mathrm{Ca}^+`.
-"""
+    def __init__(self):
+        level_data = (
+            LevelData(
+                level=self.S12,
+                Ahfs=-3225.60828640e6 * consts.h / 4,  # [1]
+                Bhfs=0,
+                g_J=2.00225664,  # [2]
+                g_I=(2 / 7) * -1.315348,  # [3]
+            ),
+            LevelData(
+                level=self.P12,
+                Ahfs=-145.4e6 * consts.h,
+                Bhfs=0,
+                g_I=(2 / 7) * -1.315348,  # [4]  # [3]
+            ),
+            LevelData(
+                level=self.P32,
+                Ahfs=-31.4e6 * consts.h,  # [4]
+                Bhfs=-6.9e6 * consts.h,  # [4]
+                g_I=(2 / 7) * -1.315348,  # [3]
+            ),
+            LevelData(
+                level=self.D32,
+                Ahfs=-47.3e6 * consts.h,  # [4]
+                Bhfs=-3.7e6 * consts.h,  # [4]
+                g_I=(2 / 7) * -1.315348,  # [3]
+            ),
+            LevelData(
+                level=self.D52,
+                Ahfs=-3.8931e6 * consts.h,  # [5]
+                Bhfs=-4.241e6 * consts.h,  # [5]
+                g_J=1.2003,
+                g_I=(2 / 7) * -1.315348,  # [3]
+            ),
+        )
 
-shelf = D52
-r""" Alias for the :math:`\left|n=3, S=1/2, L=2, J=5/2\right>` "shelf" level of
-:math:`^{43}\mathrm{Ca}^+`.
-"""
+        transitions = {
+            "397": Transition(
+                lower=self.S12,
+                upper=self.P12,
+                einstein_A=132e6,  # [?]
+                frequency=2 * np.pi * 755223443.81e6,  # [6]
+            ),
+            "393": Transition(
+                lower=self.S12,
+                upper=self.P32,
+                einstein_A=135e6,  # [?]
+                frequency=2 * np.pi * 761905691.40e6,  # [6]
+            ),
+            "866": Transition(
+                lower=self.D32,
+                upper=self.P12,
+                einstein_A=8.4e6,  # [?]
+                frequency=2 * np.pi * 345996772.78e6,  # [6]
+            ),
+            "850": Transition(
+                lower=self.D32,
+                upper=self.P32,
+                einstein_A=0.955e6,  # [?]
+                frequency=2 * np.pi * 352679020.37e6,  # [6]
+            ),
+            "854": Transition(
+                lower=self.D52,
+                upper=self.P32,
+                einstein_A=8.48e6,  # [?]
+                frequency=350859426.91e6 * 2 * np.pi,  # [6]
+            ),
+            "729": Transition(
+                lower=self.S12,
+                upper=self.D52,
+                einstein_A=0.856,  # [?]
+                frequency=411046264.4881e6 * 2 * np.pi,  # [6]
+            ),
+            "733": Transition(
+                lower=self.S12,
+                upper=self.D32,
+                einstein_A=0.850,  # [?]#
+                frequency=409226671.03e6 * 2 * np.pi,  # [6]
+            ),
+        }
+
+        super().__init__(
+            nuclear_spin=7 / 2, level_data=level_data, transitions=transitions
+        )
 
 
-level_data = (
-    LevelData(
-        level=ground_level,
-        Ahfs=-3225.60828640e6 * consts.h / 4,  # [1]
-        Bhfs=0,
-        g_J=2.00225664,  # [2]
-        g_I=(2 / 7) * -1.315348,  # [3]
-    ),
-    LevelData(
-        level=P12,
-        Ahfs=-145.4e6 * consts.h,
-        Bhfs=0,
-        g_I=(2 / 7) * -1.315348,  # [4]  # [3]
-    ),
-    LevelData(
-        level=P32,
-        Ahfs=-31.4e6 * consts.h,  # [4]
-        Bhfs=-6.9e6 * consts.h,  # [4]
-        g_I=(2 / 7) * -1.315348,  # [3]
-    ),
-    LevelData(
-        level=D32,
-        Ahfs=-47.3e6 * consts.h,  # [4]
-        Bhfs=-3.7e6 * consts.h,  # [4]
-        g_I=(2 / 7) * -1.315348,  # [3]
-    ),
-    LevelData(
-        level=D52,
-        Ahfs=-3.8931e6 * consts.h,  # [5]
-        Bhfs=-4.241e6 * consts.h,  # [5]
-        g_J=1.2003,
-        g_I=(2 / 7) * -1.315348,  # [3]
-    ),
-)
-
-transitions = {
-    "397": Transition(
-        lower=S12,
-        upper=P12,
-        einstein_A=132e6,  # [?]
-        frequency=2 * np.pi * 755223443.81e6,  # [6]
-    ),
-    "393": Transition(
-        lower=S12,
-        upper=P32,
-        einstein_A=135e6,  # [?]
-        frequency=2 * np.pi * 761905691.40e6,  # [6]
-    ),
-    "866": Transition(
-        lower=D32,
-        upper=P12,
-        einstein_A=8.4e6,  # [?]
-        frequency=2 * np.pi * 345996772.78e6,  # [6]
-    ),
-    "850": Transition(
-        lower=D32,
-        upper=P32,
-        einstein_A=0.955e6,  # [?]
-        frequency=2 * np.pi * 352679020.37e6,  # [6]
-    ),
-    "854": Transition(
-        lower=D52,
-        upper=P32,
-        einstein_A=8.48e6,  # [?]
-        frequency=350859426.91e6 * 2 * np.pi,  # [6]
-    ),
-    "729": Transition(
-        lower=S12,
-        upper=D52,
-        einstein_A=0.856,  # [?]
-        frequency=411046264.4881e6 * 2 * np.pi,  # [6]
-    ),
-    "733": Transition(
-        lower=S12,
-        upper=D32,
-        einstein_A=0.850,  # [?]#
-        frequency=409226671.03e6 * 2 * np.pi,  # [6]
-    ),
-}
-
-Ca43 = AtomFactory(nuclear_spin=7 / 2, level_data=level_data, transitions=transitions)
+Ca43 = Ca43Factory()
 r""" :math:`^{43}\mathrm{Ca}^+` atomic structure. """

--- a/atomic_physics/ions/ca43.py
+++ b/atomic_physics/ions/ca43.py
@@ -19,7 +19,7 @@ from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
 
 class Ca43Factory(AtomFactory):
-    r"""``AtomFactory`` for :math:`^{43}\mathrm{Ca}^+`.
+    r""":class:`~atomic_physics.core.AtomFactory` for :math:`^{43}\mathrm{Ca}^+`.
 
     Attributes:
         S12: the :math:`\left|n=4, S=1/2, L=0, J=1/2\right>` level.

--- a/atomic_physics/ions/mg25.py
+++ b/atomic_physics/ions/mg25.py
@@ -31,7 +31,7 @@ from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
 
 class Mg25Factory(AtomFactory):
-    r"""``AtomFactory`` for :math:`^{25}\mathrm{Mg}^+`.
+    r""":class:`~atomic_physics.core.AtomFactory` for :math:`^{25}\mathrm{Mg}^+`.
 
     Attributes:
         S12: the :math:`\left|n=3, S=1/2, L=0, J=1/2\right>` level.

--- a/atomic_physics/ions/mg25.py
+++ b/atomic_physics/ions/mg25.py
@@ -29,58 +29,68 @@ import scipy.constants as consts
 
 from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
-S12 = Level(n=3, S=1 / 2, L=0, J=1 / 2)
-r""" The :math:`\left|n=3, S=1/2, L=0, J=1/2\right>` level.
-"""
 
-P12 = Level(n=3, S=1 / 2, L=1, J=1 / 2)
-r""" The :math:`\left|n=3, S=1/2, L=1, J=1/2\right>` level."""
+class Mg25Factory(AtomFactory):
+    r"""``AtomFactory`` for :math:`^{25}\mathrm{Mg}^+`.
 
-P32 = Level(n=3, S=1 / 2, L=1, J=3 / 2)
-r""" The :math:`\left|n=3, S=1/2, L=1, J=3/2\right>` level."""
+    Attributes:
+        S12: the :math:`\left|n=3, S=1/2, L=0, J=1/2\right>` level.
+        P12: the :math:`\left|n=3, S=1/2, L=1, J=1/2\right>` level.
+        P32: the :math:`\left|n=3, S=1/2, L=1, J=3/2\right>` level.
+        ground_level: alias for the :math:`\left|n=3, S=1/2, L=0, J=1/2\right>` ground
+            level.
+    """
 
-ground_level = S12
-r""" Alias for the :math:`\left|n=3, S=1/2, L=0, J=1/2\right>` ground level of
-:math:`^{25}\mathrm{Mg}^+`.
-"""
+    S12: Level = Level(n=3, S=1 / 2, L=0, J=1 / 2)
+    P12: Level = Level(n=3, S=1 / 2, L=1, J=1 / 2)
+    P32: Level = Level(n=3, S=1 / 2, L=1, J=3 / 2)
+
+    ground_level: Level = S12
+
+    def __init__(self):
+        level_data = (
+            LevelData(
+                level=self.S12,
+                Ahfs=-596.2542487e6 * consts.h,  # [5] (or —596.254376(54)e6 [1])
+                Bhfs=0,
+                g_J=2.002,  # [1] (approximate)
+                g_I=(2 / 5) * -0.85545,  # [7]
+            ),
+            LevelData(
+                level=self.P12,
+                Ahfs=102.16e6 * consts.h,  # [6]
+                Bhfs=0,
+                g_I=(2 / 5) * -0.85545,  # [7]
+            ),
+            LevelData(
+                level=self.P32,
+                Ahfs=-19.0972e6 * consts.h,  # [8]
+                Bhfs=22.3413e6 * consts.h,  # [8]
+                g_I=(2 / 5) * -0.85545,  # [7]
+            ),
+        )
+
+        transitions = {
+            "280": Transition(
+                lower=self.S12,
+                upper=self.P12,
+                einstein_A=5.58e8,  # [4]
+                frequency=1069.339957e12 * 2 * np.pi,  # [3]
+            ),
+            "279": Transition(
+                lower=self.S12,
+                upper=self.P32,
+                einstein_A=2.60e8,  # [4]
+                frequency=1072.084547e12
+                * 2
+                * np.pi,  # [3] (or 1072084547e6 * 2 * np.pi [2])
+            ),
+        }
+
+        super().__init__(
+            nuclear_spin=5 / 2, level_data=level_data, transitions=transitions
+        )
 
 
-level_data = (
-    LevelData(
-        level=ground_level,
-        Ahfs=-596.2542487e6 * consts.h,  # [5] (or —596.254376(54)e6 [1])
-        Bhfs=0,
-        g_J=2.002,  # [1] (approximate)
-        g_I=(2 / 5) * -0.85545,  # [7]
-    ),
-    LevelData(
-        level=P12,
-        Ahfs=102.16e6 * consts.h,  # [6]
-        Bhfs=0,
-        g_I=(2 / 5) * -0.85545,  # [7]
-    ),
-    LevelData(
-        level=P32,
-        Ahfs=-19.0972e6 * consts.h,  # [8]
-        Bhfs=22.3413e6 * consts.h,  # [8]
-        g_I=(2 / 5) * -0.85545,  # [7]
-    ),
-)
-
-transitions = {
-    "280": Transition(
-        lower=S12,
-        upper=P12,
-        einstein_A=5.58e8,  # [4]
-        frequency=1069.339957e12 * 2 * np.pi,  # [3]
-    ),
-    "279": Transition(
-        lower=S12,
-        upper=P32,
-        einstein_A=2.60e8,  # [4]
-        frequency=1072.084547e12 * 2 * np.pi,  # [3] (or 1072084547e6 * 2 * np.pi [2])
-    ),
-}
-
-Mg25 = AtomFactory(nuclear_spin=5 / 2, level_data=level_data, transitions=transitions)
+Mg25 = Mg25Factory()
 r""" :math:`^{25}\mathrm{Mg}^+` atomic structure. """

--- a/atomic_physics/ions/sr88.py
+++ b/atomic_physics/ions/sr88.py
@@ -12,92 +12,89 @@ import numpy as np
 
 from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
-# level aliases
-ground_level = S12 = Level
-P12 = Level
-P32 = Level
-D32 = Level
-shelf = D52 = Level
+
+class Sr88Factory(AtomFactory):
+    r"""``AtomFactory`` for :math:`^{88}\mathrm{Sr}^+`.
+
+    Attributes:
+        S12: the :math:`\left|n=5, S=1/2, L=0, J=1/2\right>` level.
+        P12: the :math:`\left|n=5, S=1/2, L=1, J=1/2\right>` level.
+        P32: the :math:`\left|n=5, S=1/2, L=1, J=3/2\right>` level.
+        D32: the :math:`\left|n=4, S=1/2, L=2, J=3/2\right>` level.
+        D52: the :math:`\left|n=4, S=1/2, L=2, J=5/2\right>` level.
+
+        ground_level: alias for the :math:`\left|n=5, S=1/2, L=0, J=1/2\right>` ground
+            level.
+        shelf: alias for the :math:`\left|n=4, S=1/2, L=2, J=5/2\right>` "shelf" level.
+    """
+
+    S12: Level = Level(n=5, S=1 / 2, L=0, J=1 / 2)
+    P12: Level = Level(n=5, S=1 / 2, L=1, J=1 / 2)
+    P32: Level = Level(n=5, S=1 / 2, L=1, J=3 / 2)
+    D32: Level = Level(n=5, S=1 / 2, L=2, J=3 / 2)
+    D52: Level = Level(n=4, S=1 / 2, L=2, J=5 / 2)
+
+    ground_level: Level = S12
+    shelf: Level = D52
+
+    def __init__(self):
+        level_data = (
+            LevelData(level=self.S12, Ahfs=0, Bhfs=0),
+            LevelData(level=self.P12, Ahfs=0, Bhfs=0),
+            LevelData(level=self.P32, Ahfs=0, Bhfs=0),
+            LevelData(level=self.D32, Ahfs=0, Bhfs=0),
+            LevelData(level=self.D52, Ahfs=0, Bhfs=0),
+        )
+
+        transitions = {
+            "422": Transition(
+                lower=self.S12,
+                upper=self.P12,
+                einstein_A=127.9e6,  # [1]
+                frequency=2 * np.pi * 711162972859365.0,  # [1]
+            ),
+            "408": Transition(
+                lower=self.S12,
+                upper=self.P32,
+                einstein_A=141e6,  # [1]
+                frequency=2 * np.pi * 735197363032326.0,  # [1]
+            ),
+            "1092": Transition(
+                lower=self.D32,
+                upper=self.P12,
+                einstein_A=7.46e6,  # [1]
+                frequency=2 * np.pi * 274664149123480.0,  # [1]
+            ),
+            "1004": Transition(
+                lower=self.D32,
+                upper=self.P32,
+                einstein_A=1.0e6,  # [1]
+                frequency=2 * np.pi * 298697611773804.0,  # [1]
+            ),
+            "1033": Transition(
+                lower=self.D52,
+                upper=self.P32,
+                einstein_A=8.7e6,  # [1]
+                frequency=2 * np.pi * 290290973185754.0,  # [1]
+            ),
+            "674": Transition(
+                lower=self.S12,
+                upper=self.D52,
+                einstein_A=2.55885,  # [3]
+                frequency=2 * np.pi * 444779044095485.27,  # [2]
+            ),
+            "687": Transition(
+                lower=self.S12,
+                upper=self.D32,
+                einstein_A=2.299,  # [1]
+                frequency=2 * np.pi * 436495331872197.0,  # [1]
+            ),
+        }
+
+        super().__init__(
+            nuclear_spin=0.0, level_data=level_data, transitions=transitions
+        )
 
 
-S12 = Level(n=5, S=1 / 2, L=0, J=1 / 2)
-r""" The :math:`\left|n=5, S=1/2, L=0, J=1/2\right>` level.
-"""
-
-P12 = Level(n=5, S=1 / 2, L=1, J=1 / 2)
-r""" The :math:`\left|n=5, S=1/2, L=1, J=1/2\right>` level."""
-
-P32 = Level(n=5, S=1 / 2, L=1, J=3 / 2)
-r""" The :math:`\left|n=5, S=1/2, L=1, J=3/2\right>` level."""
-
-D32 = Level(n=5, S=1 / 2, L=2, J=3 / 2)
-r""" The :math:`\left|n=4, S=1/2, L=2, J=3/2\right>` level."""
-
-D52 = Level(n=4, S=1 / 2, L=2, J=5 / 2)
-r""" The :math:`\left|n=4, S=1/2, L=2, J=5/2\right>` level."""
-
-ground_level = S12
-r""" Alias for the :math:`\left|n=5, S=1/2, L=0, J=1/2\right>` ground level of
-:math:`^{88}\mathrm{Sr}^+`.
-"""
-
-shelf = D52
-r""" Alias for the :math:`\left|n=4, S=1/2, L=2, J=5/2\right>` "shelf" level of
-:math:`^{88}\mathrm{Sr}^+`.
-"""
-
-level_data = (
-    LevelData(level=ground_level, Ahfs=0, Bhfs=0),
-    LevelData(level=P12, Ahfs=0, Bhfs=0),
-    LevelData(level=P32, Ahfs=0, Bhfs=0),
-    LevelData(level=D32, Ahfs=0, Bhfs=0),
-    LevelData(level=D52, Ahfs=0, Bhfs=0),
-)
-
-transitions = {
-    "422": Transition(
-        lower=S12,
-        upper=P12,
-        einstein_A=127.9e6,  # [1]
-        frequency=2 * np.pi * 711162972859365.0,  # [1]
-    ),
-    "408": Transition(
-        lower=S12,
-        upper=P32,
-        einstein_A=141e6,  # [1]
-        frequency=2 * np.pi * 735197363032326.0,  # [1]
-    ),
-    "1092": Transition(
-        lower=D32,
-        upper=P12,
-        einstein_A=7.46e6,  # [1]
-        frequency=2 * np.pi * 274664149123480.0,  # [1]
-    ),
-    "1004": Transition(
-        lower=D32,
-        upper=P32,
-        einstein_A=1.0e6,  # [1]
-        frequency=2 * np.pi * 298697611773804.0,  # [1]
-    ),
-    "1033": Transition(
-        lower=D52,
-        upper=P32,
-        einstein_A=8.7e6,  # [1]
-        frequency=2 * np.pi * 290290973185754.0,  # [1]
-    ),
-    "674": Transition(
-        lower=S12,
-        upper=D52,
-        einstein_A=2.55885,  # [3]
-        frequency=2 * np.pi * 444779044095485.27,  # [2]
-    ),
-    "687": Transition(
-        lower=S12,
-        upper=D32,
-        einstein_A=2.299,  # [1]
-        frequency=2 * np.pi * 436495331872197.0,  # [1]
-    ),
-}
-
-Sr88 = AtomFactory(nuclear_spin=0, level_data=level_data, transitions=transitions)
+Sr88 = Sr88Factory()
 r""" :math:`^{88}\mathrm{Sr}^+` atomic structure. """

--- a/atomic_physics/ions/sr88.py
+++ b/atomic_physics/ions/sr88.py
@@ -14,7 +14,7 @@ from atomic_physics.core import AtomFactory, Level, LevelData, Transition
 
 
 class Sr88Factory(AtomFactory):
-    r"""``AtomFactory`` for :math:`^{88}\mathrm{Sr}^+`.
+    r""":class:`~atomic_physics.core.AtomFactory` for :math:`^{88}\mathrm{Sr}^+`.
 
     Attributes:
         S12: the :math:`\left|n=5, S=1/2, L=0, J=1/2\right>` level.

--- a/atomic_physics/ions/sr88.py
+++ b/atomic_physics/ions/sr88.py
@@ -31,7 +31,7 @@ class Sr88Factory(AtomFactory):
     S12: Level = Level(n=5, S=1 / 2, L=0, J=1 / 2)
     P12: Level = Level(n=5, S=1 / 2, L=1, J=1 / 2)
     P32: Level = Level(n=5, S=1 / 2, L=1, J=3 / 2)
-    D32: Level = Level(n=5, S=1 / 2, L=2, J=3 / 2)
+    D32: Level = Level(n=4, S=1 / 2, L=2, J=3 / 2)
     D52: Level = Level(n=4, S=1 / 2, L=2, J=5 / 2)
 
     ground_level: Level = S12

--- a/atomic_physics/rate_equations.py
+++ b/atomic_physics/rate_equations.py
@@ -18,23 +18,23 @@ class Rates:
        from scipy.linalg import expm
 
        from atomic_physics.core import Laser
-       from atomic_physics.ions import ca43
+       from atomic_physics.ions.ca43 import Ca43
        from atomic_physics.rate_equations import Rates
 
        t_ax = np.linspace(0, 100e-6, 100)  # Scan the duration of the "shelving" pulse
        intensity = 0.02  # 393 intensity
 
-       ion = ca43.Ca43(magnetic_field=146e-4)
+       ion = Ca43(magnetic_field=146e-4)
 
        # Ion starts in the F=4, M=+4 "stretched" state within the 4S1/2 ground-level
-       stretch = ion.get_state_for_F(ca43.ground_level, F=4, M_F=+4)
+       stretch = ion.get_state_for_F(Ca43.ground_level, F=4, M_F=+4)
        Vi = np.zeros((ion.num_states, 1))
        Vi[stretch] = 1
 
        # Tune the 393nm laser to resonance with the
        # 4S1/2(F=4, M_F=+4) <> 4P3/2(F=5, M_F=+5) transition
        detuning = ion.get_transition_frequency_for_states(
-           (stretch, ion.get_state_for_F(ca43.P32, F=5, M_F=+5))
+           (stretch, ion.get_state_for_F(Ca43.P32, F=5, M_F=+5))
        )
        lasers = (
            Laser("393", polarization=+1, intensity=intensity, detuning=detuning),
@@ -46,7 +46,7 @@ class Rates:
        shelved = np.zeros(len(t_ax))  # Population in the 3D5/2 level at the end
        for idx, t in np.ndenumerate(t_ax):
            Vf = expm(transitions * t) @ Vi  # NB use of matrix operations here!
-           shelved[idx] = np.sum(Vf[ion.get_slice_for_level(ca43.shelf)])
+           shelved[idx] = np.sum(Vf[ion.get_slice_for_level(Ca43.shelf)])
 
        plt.plot(t_ax * 1e6, shelved)
        plt.ylabel("Shelved Population")

--- a/atomic_physics/tests/test_atom.py
+++ b/atomic_physics/tests/test_atom.py
@@ -4,7 +4,9 @@ import numpy as np
 from scipy import constants as consts
 
 from atomic_physics.core import AtomFactory, Level, LevelData
-from atomic_physics.ions import ba133, ba137, ca43
+from atomic_physics.ions.ba133 import Ba133
+from atomic_physics.ions.ba137 import Ba137
+from atomic_physics.ions.ca43 import Ca43
 from atomic_physics.operators import (
     AngularMomentumLoweringOp,
     AngularMomentumProjectionOp,
@@ -25,7 +27,7 @@ class TestAtom(unittest.TestCase):
         """Check that the ``num_states`` is calculated correctly and that all attributes
         have the correct shape.
         """
-        ion = ca43.Ca43(magnetic_field=146.0942e-4)
+        ion = Ca43(magnetic_field=146.0942e-4)
 
         num_states = 0
         for level in ion.level_data.keys():
@@ -47,8 +49,8 @@ class TestAtom(unittest.TestCase):
         Check the calculation for ``state_vectors`` against values for the ground-level
         of 43Ca+ at 146G using [1] table E.2.
         """
-        ion = ca43.Ca43(magnetic_field=146.0942e-4)
-        level_slice = ion.get_slice_for_level(ca43.ground_level)
+        ion = Ca43(magnetic_field=146.0942e-4)
+        level_slice = ion.get_slice_for_level(Ca43.ground_level)
 
         # M, ((M_J, M_I, coeff_M_J, coeff_M_I))
         expansions = (
@@ -71,7 +73,7 @@ class TestAtom(unittest.TestCase):
         for expansion_idx, (M, (alpha_expansion, beta_expansion)) in enumerate(
             expansions
         ):
-            indicies = ion.get_states_for_M(level=ca43.S12, M=M)
+            indicies = ion.get_states_for_M(level=Ca43.S12, M=M)
 
             for ind in indicies:
                 state_vector = state_vectors[:, ind]
@@ -128,10 +130,10 @@ class TestAtom(unittest.TestCase):
 
     def test_levels(self):
         """Check ``levels`` is formed correctly."""
-        ion = ca43.Ca43(magnetic_field=1.0)
+        ion = Ca43(magnetic_field=1.0)
         assert len(set(ion.levels)) == len(ion.levels)
         assert set(ion.levels) == set(
-            [ca43.S12, ca43.P12, ca43.P32, ca43.D32, ca43.D52]
+            [Ca43.S12, Ca43.P12, Ca43.P32, Ca43.D32, Ca43.D52]
         )
         assert set(ion.levels) == set(ion.level_data.keys())
         assert set(ion.levels) == set(ion.level_states.keys())
@@ -146,7 +148,7 @@ class TestAtom(unittest.TestCase):
 
         This also checks the behaviour of ``get_transition_for_levels``.
         """
-        ion = ca43.Ca43(magnetic_field=146.0942e-4)
+        ion = Ca43(magnetic_field=146.0942e-4)
 
         # check that the mean energy of every level is zero (state energies are defined
         # relative to the level's centre of gravity)
@@ -182,8 +184,8 @@ class TestAtom(unittest.TestCase):
             (+4, +3, 2.873631427),
         )
         for M_4, M_3, ref_frequency in ref:
-            F_4_ind = ion.get_state_for_F(level=ca43.ground_level, F=4, M_F=M_4)
-            F_3_ind = ion.get_state_for_F(level=ca43.ground_level, F=3, M_F=M_3)
+            F_4_ind = ion.get_state_for_F(level=Ca43.ground_level, F=4, M_F=M_4)
+            F_3_ind = ion.get_state_for_F(level=Ca43.ground_level, F=3, M_F=M_3)
 
             np.testing.assert_allclose(
                 (ion.state_energies[F_3_ind] - ion.state_energies[F_4_ind])
@@ -199,22 +201,13 @@ class TestAtom(unittest.TestCase):
                 atol=1,
             )
 
-            np.testing.assert_allclose(
-                ion.get_transition_frequency_for_states(
-                    states=(F_4_ind, F_3_ind), relative=False
-                )
-                / (2 * np.pi),
-                ref_frequency * 1e9,
-                atol=1,
-            )
-
     def test_magnetic_dipoles(self):
         """
         Check the calculation for `state_vectors` for 43Ca+ at 146G against [1] table E.4.
         """
         uB = consts.physical_constants["Bohr magneton"][0]
-        ion = ca43.Ca43(magnetic_field=146.0942e-4)
-        level_slice = ion.get_slice_for_level(ca43.ground_level)
+        ion = Ca43(magnetic_field=146.0942e-4)
+        level_slice = ion.get_slice_for_level(Ca43.ground_level)
 
         magnetic_dipoles = ion.get_magnetic_dipoles()
 
@@ -243,8 +236,8 @@ class TestAtom(unittest.TestCase):
         )
 
         for M4, M3, R_ref in values:
-            u_index = ion.get_state_for_F(ca43.S12, F=3, M_F=M3)
-            l_index = ion.get_state_for_F(ca43.S12, F=4, M_F=M4)
+            u_index = ion.get_state_for_F(Ca43.S12, F=3, M_F=M3)
+            l_index = ion.get_state_for_F(Ca43.S12, F=4, M_F=M4)
 
             np.testing.assert_allclose(
                 np.abs(magnetic_dipoles[u_index, l_index]) / uB, R_ref, atol=1e-6
@@ -252,7 +245,7 @@ class TestAtom(unittest.TestCase):
 
         # Check all forbidden transitions have 0 matrix element
         # Check that Rnm = (-1)^q Rmn
-        level = ca43.S12
+        level = Ca43.S12
         level_slice = ion.get_slice_for_level(level)
         for i_ind in np.arange(ion.num_states)[level_slice]:
             for j_ind in np.arange(ion.num_states)[level_slice]:
@@ -276,12 +269,12 @@ class TestAtom(unittest.TestCase):
         This test looks at the ground level of 137Ba+, which has a positive hyperfine A
         coefficient.
         """
-        level = ba137.ground_level
-        Ba137 = ba137.Ba137.filter_levels(level_filter=(level,))
+        level = Ba137.ground_level
+        factory = Ba137.filter_levels(level_filter=(level,))
 
         # Make sure we get the relationships right over a range of fields
         for magnetic_field in [1e-4, 100e-4, 1000e-4, 1, 10]:
-            ion = Ba137(magnetic_field=magnetic_field)
+            ion = factory(magnetic_field=magnetic_field)
 
             # 137Ba+ has I=3/2 so the ground level has F=1 and F=2. A is positive so
             # F=2 has higher energy.
@@ -306,12 +299,12 @@ class TestAtom(unittest.TestCase):
         This test looks at the ground level of 133Ba+, which has a negative hyperfine A
         coefficient.
         """
-        level = ba133.ground_level
-        Ba133 = ba133.Ba133.filter_levels(level_filter=(level,))
+        level = Ba133.ground_level
+        factory = Ba133.filter_levels(level_filter=(level,))
 
         # Make sure we get the relationships right over a range of fields
         for magnetic_field in [1e-4, 100e-4, 1000e-4, 1, 10]:
-            ion = Ba133(magnetic_field=magnetic_field)
+            ion = factory(magnetic_field=magnetic_field)
 
             # 133Ba+ has I=1/2 so the ground level has F=0 and F=1. A is negative so
             # F=1 has higher energy.
@@ -332,11 +325,11 @@ class TestAtom(unittest.TestCase):
         This test looks at the D level of 137Ba+, which has a positive hyperfine A
         coefficient and a negative B coefficient.
         """
-        level = ba137.shelf
-        Ba137 = ba137.Ba137.filter_levels(level_filter=(level,))
+        level = Ba137.shelf
+        factory = Ba137.filter_levels(level_filter=(level,))
 
         for magnetic_field in [1e-6, 1e-4, 10e-4, 100]:
-            ion = Ba137(magnetic_field=1e-9)
+            ion = factory(magnetic_field=1e-9)
 
             # 137Ba+ has I=3/2 so the ground level F=1, F=2, F=3, F=4. A is negative and
             # (just) outweighs B (which is positive) so F=1 has highest energy.
@@ -438,10 +431,10 @@ class TestAtom(unittest.TestCase):
 
     def test_M_I_M_J(self):
         """Check ordering of M_I and M_J by looking at level structure of 137Ba+."""
-        ion = ba137.Ba137(magnetic_field=10.0)
+        ion = Ba137(magnetic_field=10.0)
 
         # Start by checking states in the ground level against their known ordering
-        level = ba137.ground_level
+        level = Ba137.ground_level
         self.assertEqual(
             ion.get_state_for_F(
                 level,
@@ -528,7 +521,7 @@ class TestAtom(unittest.TestCase):
 
     def test_get_slice_for_level(self):
         """Test for ``get_slice_for_level``."""
-        ion = ca43.Ca43(1)
+        ion = Ca43(1)
 
         # check that all states are included in at exactly one slice
         all_states = np.full(ion.num_states, False, dtype=bool)
@@ -546,7 +539,7 @@ class TestAtom(unittest.TestCase):
 
     def test_get_states_for_level(self):
         """Test for ``get_states_for_level``."""
-        ion = ca43.Ca43(1)
+        ion = Ca43(1)
 
         # check that all states are included in at exactly one slice
         all_states = np.full(ion.num_states, False, dtype=bool)
@@ -565,7 +558,7 @@ class TestAtom(unittest.TestCase):
 
     def test_get_level_for_state(self):
         """Test for ``get_level_for_state``."""
-        ion = ca43.Ca43(1)
+        ion = Ca43(1)
         for state in range(ion.num_states):
             level = ion.get_level_for_state(state)
             level_slice = ion.get_slice_for_level(level)
@@ -574,7 +567,7 @@ class TestAtom(unittest.TestCase):
 
     def test_get_transition_for_levels(self):
         """Test for ``get_transition_for_levels``."""
-        ion = ca43.Ca43(1)
+        ion = Ca43(1)
         for transition in ion.transitions.values():
             assert (
                 ion.get_transition_for_levels((transition.lower, transition.upper))
@@ -587,8 +580,8 @@ class TestAtom(unittest.TestCase):
 
     def test_get_rabi_rf(self):
         """Test for ``get_rabi_rf``."""
-        ion = ca43.Ca43(magnetic_field=146e-4)
-        level = ca43.ground_level
+        ion = Ca43(magnetic_field=146e-4)
+        level = Ca43.ground_level
         level_slice = ion.get_slice_for_level(level)
         mpoles = ion.get_magnetic_dipoles()
         for ii in range(level_slice.start, level_slice.stop):
@@ -598,7 +591,7 @@ class TestAtom(unittest.TestCase):
 
     def test_get_states_for_M(self):
         """Test for ``get_states_for_M``."""
-        ion = ca43.Ca43(magnetic_field=146e-4)
+        ion = Ca43(magnetic_field=146e-4)
         for level in ion.level_data.keys():
             F_min = np.abs(ion.nuclear_spin - level.J)
             F_max = ion.nuclear_spin + level.J
@@ -616,7 +609,7 @@ class TestAtom(unittest.TestCase):
 
     def test_get_saturation_intensity(self):
         """Test for ``get_saturation_intensity``."""
-        ion = ca43.Ca43(1)
+        ion = Ca43(1)
 
         # saturation intensities for 43Ca+ transitions from [2]
         # units are Wm^-2
@@ -634,7 +627,7 @@ class TestAtom(unittest.TestCase):
 
     def test_intensity_to_power(self):
         """Test for ``intensity_to_power``."""
-        ion = ca43.Ca43(1)
+        ion = Ca43(1)
         waist = 10e-6
         power = ion.intensity_to_power(
             transition="397",

--- a/atomic_physics/tests/test_atom_factory.py
+++ b/atomic_physics/tests/test_atom_factory.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from atomic_physics.ions import ca43
+from atomic_physics.ions.ca43 import Ca43
 
 
 class TestAtomFactory(unittest.TestCase):
@@ -12,16 +12,16 @@ class TestAtomFactory(unittest.TestCase):
         """
         Test that the atom factory sorts the levels into energy ordering correctly.
         """
-        ion = ca43.Ca43(magnetic_field=1.0)
+        ion = Ca43(magnetic_field=1.0)
         levels_sorted = sorted(
             ion.level_states.items(), key=lambda item: item[1].frequency
         )
 
-        assert levels_sorted[0][0] == ca43.S12
-        assert levels_sorted[1][0] == ca43.D32
-        assert levels_sorted[2][0] == ca43.D52
-        assert levels_sorted[3][0] == ca43.P12
-        assert levels_sorted[4][0] == ca43.P32
+        assert levels_sorted[0][0] == Ca43.S12
+        assert levels_sorted[1][0] == Ca43.D32
+        assert levels_sorted[2][0] == Ca43.D52
+        assert levels_sorted[3][0] == Ca43.P12
+        assert levels_sorted[4][0] == Ca43.P32
 
         # check all levels have the right energy
         assert levels_sorted[0][1].frequency == 0  # S 1/2 is the ground level
@@ -50,28 +50,28 @@ class TestAtomFactory(unittest.TestCase):
             assert states.stop_index == states.start_index + states.num_states
 
         # states should be in reverse energy order
-        assert ion.level_states[ca43.P32].start_index == 0
+        assert ion.level_states[Ca43.P32].start_index == 0
         assert (
-            ion.level_states[ca43.P12].start_index
-            == ion.level_states[ca43.P32].stop_index
+            ion.level_states[Ca43.P12].start_index
+            == ion.level_states[Ca43.P32].stop_index
         )
         assert (
-            ion.level_states[ca43.D52].start_index
-            == ion.level_states[ca43.P12].stop_index
+            ion.level_states[Ca43.D52].start_index
+            == ion.level_states[Ca43.P12].stop_index
         )
         assert (
-            ion.level_states[ca43.D32].start_index
-            == ion.level_states[ca43.D52].stop_index
+            ion.level_states[Ca43.D32].start_index
+            == ion.level_states[Ca43.D52].stop_index
         )
         assert (
-            ion.level_states[ca43.S12].start_index
-            == ion.level_states[ca43.D32].stop_index
+            ion.level_states[Ca43.S12].start_index
+            == ion.level_states[Ca43.D32].stop_index
         )
 
     def test_filtering(self):
         """Test that the level filtering works correctly."""
-        levels = (ca43.S12, ca43.D32, ca43.P12, ca43.P32)
-        factory = ca43.Ca43.filter_levels(level_filter=levels)
+        levels = (Ca43.S12, Ca43.D32, Ca43.P12, Ca43.P32)
+        factory = Ca43.filter_levels(level_filter=levels)
         ion = factory(magnetic_field=1.0)
         assert len(ion.levels) == len(set(ion.levels))
         assert set(ion.levels) == set(levels)
@@ -80,10 +80,10 @@ class TestAtomFactory(unittest.TestCase):
             ion.level_states.items(), key=lambda item: item[1].frequency
         )
 
-        assert levels_sorted[0][0] == ca43.S12
-        assert levels_sorted[1][0] == ca43.D32
-        assert levels_sorted[2][0] == ca43.P12
-        assert levels_sorted[3][0] == ca43.P32
+        assert levels_sorted[0][0] == Ca43.S12
+        assert levels_sorted[1][0] == Ca43.D32
+        assert levels_sorted[2][0] == Ca43.P12
+        assert levels_sorted[3][0] == Ca43.P32
 
         assert levels_sorted[0][1].frequency == 0  # S 1/2 is the ground level
         np.testing.assert_allclose(
@@ -102,21 +102,21 @@ class TestAtomFactory(unittest.TestCase):
         )
 
         # states should be in reverse energy order
-        assert ion.level_states[ca43.P32].start_index == 0
+        assert ion.level_states[Ca43.P32].start_index == 0
         assert (
-            ion.level_states[ca43.P12].start_index
-            == ion.level_states[ca43.P32].stop_index
+            ion.level_states[Ca43.P12].start_index
+            == ion.level_states[Ca43.P32].stop_index
         )
         assert (
-            ion.level_states[ca43.D32].start_index
-            == ion.level_states[ca43.P12].stop_index
+            ion.level_states[Ca43.D32].start_index
+            == ion.level_states[Ca43.P12].stop_index
         )
         assert (
-            ion.level_states[ca43.S12].start_index
-            == ion.level_states[ca43.D32].stop_index
+            ion.level_states[Ca43.S12].start_index
+            == ion.level_states[Ca43.D32].stop_index
         )
 
-        levels = (ca43.D32, ca43.P12, ca43.P32)
+        levels = (Ca43.D32, Ca43.P12, Ca43.P32)
 
         factory = factory.filter_levels(level_filter=levels)
         ion = factory(magnetic_field=1.0)
@@ -128,9 +128,9 @@ class TestAtomFactory(unittest.TestCase):
             ion.level_states.items(), key=lambda item: item[1].frequency
         )
 
-        assert levels_sorted[0][0] == ca43.D32
-        assert levels_sorted[1][0] == ca43.P12
-        assert levels_sorted[2][0] == ca43.P32
+        assert levels_sorted[0][0] == Ca43.D32
+        assert levels_sorted[1][0] == Ca43.P12
+        assert levels_sorted[2][0] == Ca43.P32
 
         assert levels_sorted[0][1].frequency == 0
         np.testing.assert_allclose(
@@ -141,22 +141,22 @@ class TestAtomFactory(unittest.TestCase):
         )
 
         # states should be in reverse energy order
-        assert ion.level_states[ca43.P32].start_index == 0
+        assert ion.level_states[Ca43.P32].start_index == 0
         assert (
-            ion.level_states[ca43.P12].start_index
-            == ion.level_states[ca43.P32].stop_index
+            ion.level_states[Ca43.P12].start_index
+            == ion.level_states[Ca43.P32].stop_index
         )
         assert (
-            ion.level_states[ca43.D32].start_index
-            == ion.level_states[ca43.P12].stop_index
+            ion.level_states[Ca43.D32].start_index
+            == ion.level_states[Ca43.P12].stop_index
         )
 
-        levels = (ca43.D32,)
+        levels = (Ca43.D32,)
         factory = factory.filter_levels(level_filter=levels)
         ion = factory(magnetic_field=1.0)
 
         assert len(ion.levels) == len(set(ion.levels))
         assert set(ion.levels) == set(levels)
 
-        assert ion.level_states[ca43.D32].frequency == 0
-        assert ion.level_states[ca43.D32].start_index == 0
+        assert ion.level_states[Ca43.D32].frequency == 0
+        assert ion.level_states[Ca43.D32].start_index == 0

--- a/atomic_physics/tests/test_atom_factory.py
+++ b/atomic_physics/tests/test_atom_factory.py
@@ -8,6 +8,13 @@ from atomic_physics.ions.ca43 import Ca43
 class TestAtomFactory(unittest.TestCase):
     """Tests for :class:`atomic_physics.core.AtomFactory`."""
 
+    def test_num_states(self):
+        ion = Ca43(magnetic_field=146.0942e-4)
+        num_states = 0
+        for level in ion.level_data.keys():
+            num_states += (2 * ion.nuclear_spin + 1) * (2 * level.J + 1)
+        assert num_states == Ca43.num_states
+
     def test_sorting(self):
         """
         Test that the atom factory sorts the levels into energy ordering correctly.

--- a/atomic_physics/tests/test_atoms.py
+++ b/atomic_physics/tests/test_atoms.py
@@ -3,8 +3,15 @@ import unittest
 import numpy as np
 from scipy import constants as consts
 
-from atomic_physics.atoms import two_state
-from atomic_physics.ions import ba133, ba135, ba137, ba138, ca40, ca43, mg25, sr88
+from atomic_physics.atoms.two_state import TwoStateAtom
+from atomic_physics.ions.ba133 import Ba133
+from atomic_physics.ions.ba135 import Ba135
+from atomic_physics.ions.ba137 import Ba137
+from atomic_physics.ions.ba138 import Ba138
+from atomic_physics.ions.ca40 import Ca40
+from atomic_physics.ions.ca43 import Ca43
+from atomic_physics.ions.mg25 import Mg25
+from atomic_physics.ions.sr88 import Sr88
 
 
 class TestAtoms(unittest.TestCase):
@@ -12,15 +19,15 @@ class TestAtoms(unittest.TestCase):
 
     def test_atoms(self):
         atoms = (
-            ba133.Ba133,
-            ba135.Ba135,
-            ba137.Ba137,
-            ba138.Ba138,
-            ca40.Ca40,
-            ca43.Ca43,
-            mg25.Mg25,
-            sr88.Sr88,
-            two_state.TwoStateAtom,
+            Ba133,
+            Ba135,
+            Ba137,
+            Ba138,
+            Ca40,
+            Ca43,
+            Mg25,
+            Sr88,
+            TwoStateAtom,
         )
 
         # check we can construct the atom without error
@@ -37,34 +44,27 @@ class TestAtoms(unittest.TestCase):
                 )
 
         # check the pre-defined levels exist
-        atoms = (
-            (ba133, ba133.Ba133),
-            (ba135, ba135.Ba135),
-            (ba137, ba137.Ba137),
-            (ba138, ba138.Ba138),
-            (ca40, ca40.Ca40),
-            (ca43, ca43.Ca43),
-            (sr88, sr88.Sr88),
-        )
+        atoms_d = (Ba133, Ba135, Ba137, Ba138, Ca40, Ca43, Sr88)
+
         level_names = ("S12", "P12", "P32", "D32", "D52", "ground_level", "shelf")
-        for module, factory in atoms:
+        for factory in atoms_d:
             atom = factory(1.0)
-            levels = [getattr(module, level_name) for level_name in level_names]
+            levels = [getattr(factory, level_name) for level_name in level_names]
             assert set(atom.levels) == set(levels)
 
-        atoms = ((mg25, mg25.Mg25),)
+        atoms_no_d = (Mg25,)
         level_names = (
             "S12",
             "P12",
             "P32",
             "ground_level",
         )
-        for module, factory in atoms:
+        for factory in atoms_no_d:
             atom = factory(1.0)
-            levels = [getattr(module, level_name) for level_name in level_names]
+            levels = [getattr(factory, level_name) for level_name in level_names]
             assert set(atom.levels) == set(levels)
 
-        atom = two_state.TwoStateAtom(magnetic_field=1.0)
-        assert set(atom.levels) == set((two_state.ground_level,))
-        assert two_state.upper_state == 0
-        assert two_state.lower_state == 1
+        atom = TwoStateAtom(magnetic_field=1.0)
+        assert set(atom.levels) == set((TwoStateAtom.ground_level,))
+        assert TwoStateAtom.upper_state == 0
+        assert TwoStateAtom.lower_state == 1

--- a/atomic_physics/tests/test_ca43.py
+++ b/atomic_physics/tests/test_ca43.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from atomic_physics.ions import ca43
+from atomic_physics.ions.ca43 import Ca43
 from atomic_physics.utils import field_insensitive_point
 
 
@@ -18,14 +18,14 @@ class TestCa43(unittest.TestCase):
         """Compare values we compute for the for field-insensitive
         S1/2 4,4 -> D5/2 4,3 transition at 3.38 G and 4.96 G with [1].
         """
-        Ca43 = ca43.Ca43.filter_levels(level_filter=(ca43.S12, ca43.D52))
+        factory = Ca43.filter_levels(level_filter=(Ca43.S12, Ca43.D52))
         # Start with the field-insensitive transition at around 3G
         B0 = field_insensitive_point(
-            Ca43,
-            level_0=ca43.S12,
+            factory,
+            level_0=Ca43.S12,
             F_0=4,
             M_F_0=+4,
-            level_1=ca43.D52,
+            level_1=Ca43.D52,
             F_1=4,
             M_F_1=+3,
             magnetic_field_guess=3.38e-4,
@@ -34,11 +34,11 @@ class TestCa43(unittest.TestCase):
 
         # Field-insensitive transition at around 5G
         B0 = field_insensitive_point(
-            Ca43,
-            level_0=ca43.S12,
+            factory,
+            level_0=Ca43.S12,
             F_0=4,
             M_F_0=+4,
-            level_1=ca43.D52,
+            level_1=Ca43.D52,
             F_1=4,
             M_F_1=+3,
             magnetic_field_guess=5e-4,
@@ -49,13 +49,13 @@ class TestCa43(unittest.TestCase):
         """Compare values we compute for the field-insensitive S1/2 4,0 -> S1/2 3,1
         transition at 146.094G to [1].
         """
-        Ca43 = ca43.Ca43.filter_levels(level_filter=(ca43.S12,))
+        factory = Ca43.filter_levels(level_filter=(Ca43.S12,))
         B0 = field_insensitive_point(
-            Ca43,
-            level_0=ca43.S12,
+            factory,
+            level_0=Ca43.S12,
             F_0=4,
             M_F_0=0,
-            level_1=ca43.S12,
+            level_1=Ca43.S12,
             F_1=3,
             M_F_1=+1,
             magnetic_field_guess=140e-4,
@@ -66,13 +66,13 @@ class TestCa43(unittest.TestCase):
         """Compare values we compute for field-insensitive S1/2 4,1 -> S1/2 3,1
         transition at 288G to [1].
         """
-        Ca43 = ca43.Ca43.filter_levels(level_filter=(ca43.S12,))
+        factory = Ca43.filter_levels(level_filter=(Ca43.S12,))
         B0 = field_insensitive_point(
-            Ca43,
-            level_0=ca43.S12,
+            factory,
+            level_0=Ca43.S12,
             F_0=4,
             M_F_0=+1,
-            level_1=ca43.S12,
+            level_1=Ca43.S12,
             F_1=3,
             M_F_1=+1,
             magnetic_field_guess=288e-4,

--- a/atomic_physics/tests/test_mg25.py
+++ b/atomic_physics/tests/test_mg25.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from atomic_physics.ions import mg25
+from atomic_physics.ions.mg25 import Mg25
 from atomic_physics.utils import field_insensitive_point
 
 
@@ -18,20 +18,20 @@ class TestMg25(unittest.TestCase):
         """Compare data for the field-insensitive S1/2 3,1 -> S1/2 2,1 transition at
         212.8 G to [1].
         """
-        Mg25 = mg25.Mg25.filter_levels(level_filter=(mg25.S12,))
+        factory = Mg25.filter_levels(level_filter=(Mg25.S12,))
         B0 = field_insensitive_point(
-            Mg25,
-            level_0=mg25.S12,
+            factory,
+            level_0=Mg25.S12,
             F_0=3,
             M_F_0=+1,
-            level_1=mg25.S12,
+            level_1=Mg25.S12,
             F_1=2,
             M_F_1=+1,
             magnetic_field_guess=212.8e-4,
         )
         np.testing.assert_allclose(B0, 212.8e-4, atol=1e-5)
 
-        ion = Mg25(magnetic_field=B0)
+        ion = factory(magnetic_field=B0)
         ref = (
             [3, 2, 1.326456],
             [2, 2, 1.460516],
@@ -44,8 +44,8 @@ class TestMg25(unittest.TestCase):
         for M_3, M_2, ref_freq in ref:
             freq = ion.get_transition_frequency_for_states(
                 (
-                    ion.get_state_for_F(mg25.S12, F=3, M_F=M_3),
-                    ion.get_state_for_F(mg25.S12, F=2, M_F=M_2),
+                    ion.get_state_for_F(Mg25.S12, F=3, M_F=M_3),
+                    ion.get_state_for_F(Mg25.S12, F=2, M_F=M_2),
                 ),
             )
 

--- a/atomic_physics/tests/test_polarization.py
+++ b/atomic_physics/tests/test_polarization.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from atomic_physics.ions import ca43
+from atomic_physics.ions.ca43 import Ca43
 from atomic_physics.polarization import (
     PI_POLARIZATION,
     SIGMA_MINUS_POLARIZATION,
@@ -51,13 +51,13 @@ class TestPolarization(unittest.TestCase):
 
     def test_dM_for_transition(self):
         """Check ``dM_for_transition``."""
-        ion = ca43.Ca43(magnetic_field=146e-4)
+        ion = Ca43(magnetic_field=146e-4)
 
         dM = dM_for_transition(
             atom=ion,
             states=(
-                ion.get_state_for_F(level=ca43.D52, F=3, M_F=+1),
-                ion.get_state_for_F(level=ca43.D52, F=4, M_F=+1),
+                ion.get_state_for_F(level=Ca43.D52, F=3, M_F=+1),
+                ion.get_state_for_F(level=Ca43.D52, F=4, M_F=+1),
             ),
         )
         assert np.isclose(dM, 0)
@@ -65,8 +65,8 @@ class TestPolarization(unittest.TestCase):
         dM = dM_for_transition(
             atom=ion,
             states=(
-                ion.get_state_for_F(level=ca43.D52, F=3, M_F=0),  # state 67
-                ion.get_state_for_F(level=ca43.D52, F=4, M_F=+1),  # state 74
+                ion.get_state_for_F(level=Ca43.D52, F=3, M_F=0),  # state 67
+                ion.get_state_for_F(level=Ca43.D52, F=4, M_F=+1),  # state 74
             ),
         )
         assert np.isclose(dM, -1)
@@ -74,8 +74,8 @@ class TestPolarization(unittest.TestCase):
         dM = dM_for_transition(
             atom=ion,
             states=(
-                ion.get_state_for_F(level=ca43.D52, F=4, M_F=+1),  # state 74
-                ion.get_state_for_F(level=ca43.D52, F=3, M_F=0),  # state 67
+                ion.get_state_for_F(level=Ca43.D52, F=4, M_F=+1),  # state 74
+                ion.get_state_for_F(level=Ca43.D52, F=3, M_F=0),  # state 67
             ),
         )
         assert np.isclose(dM, -1)

--- a/atomic_physics/tests/test_rates.py
+++ b/atomic_physics/tests/test_rates.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 
 from atomic_physics.core import Laser
-from atomic_physics.ions import ca43
+from atomic_physics.ions.ca43 import Ca43
 from atomic_physics.rate_equations import Rates
 
 
@@ -27,10 +27,10 @@ class TestTSS(unittest.TestCase):
         """
         intensity_list = [1e-3, 1e-1, 0.3, 1, 1.0, 2, 10.0, 1.2e4]
 
-        Ca43 = ca43.Ca43.filter_levels(level_filter=(ca43.ground_level, ca43.P32))
-        ion = Ca43(magnetic_field=5e-4)
-        s_idx = ion.get_state_for_F(ca43.ground_level, F=4, M_F=+4)
-        p_idx = ion.get_state_for_F(ca43.P32, F=5, M_F=+5)
+        factory = Ca43.filter_levels(level_filter=(Ca43.ground_level, Ca43.P32))
+        ion = factory(magnetic_field=5e-4)
+        s_idx = ion.get_state_for_F(Ca43.ground_level, F=4, M_F=+4)
+        p_idx = ion.get_state_for_F(Ca43.P32, F=5, M_F=+5)
 
         rates = Rates(ion)
         detuning = ion.get_transition_frequency_for_states((s_idx, p_idx))
@@ -46,7 +46,7 @@ class TestTSS(unittest.TestCase):
 
     def test_steady_state(self):
         """Check that the steady-state solution is found correctly."""
-        ion = ca43.Ca43(magnetic_field=5e-4)
+        ion = Ca43(magnetic_field=5e-4)
         rates = Rates(ion)
         lasers = (
             Laser("397", polarization=+1, intensity=1, detuning=0),
@@ -64,11 +64,11 @@ class TestTSS(unittest.TestCase):
         # use both integers and floats
         intensity_list = [1e-3, 1e-1, 0.3, 1, 1.0, 2, 10.0, 1.2e4]
 
-        Ca43 = ca43.Ca43.filter_levels(level_filter=(ca43.ground_level, ca43.P32))
-        ion = Ca43(magnetic_field=5e-4)
+        factory = Ca43.filter_levels(level_filter=(Ca43.ground_level, Ca43.P32))
+        ion = factory(magnetic_field=5e-4)
 
-        s_idx = ion.get_state_for_F(ca43.ground_level, F=4, M_F=+4)
-        p_idx = ion.get_state_for_F(ca43.P32, F=5, M_F=+5)
+        s_idx = ion.get_state_for_F(Ca43.ground_level, F=4, M_F=+4)
+        p_idx = ion.get_state_for_F(Ca43.P32, F=5, M_F=+5)
 
         rates = Rates(ion)
         detuning = ion.get_transition_frequency_for_states((s_idx, p_idx))
@@ -92,11 +92,11 @@ class TestTSS(unittest.TestCase):
         """Test steady state detuning dependence"""
 
         # assume 1 saturation intensity
-        Ca43 = ca43.Ca43.filter_levels(level_filter=(ca43.ground_level, ca43.P32))
-        ion = Ca43(magnetic_field=5e-4)
+        factory = Ca43.filter_levels(level_filter=(Ca43.ground_level, Ca43.P32))
+        ion = factory(magnetic_field=5e-4)
 
-        s_idx = ion.get_state_for_F(ca43.ground_level, F=4, M_F=+4)
-        p_idx = ion.get_state_for_F(ca43.P32, F=5, M_F=+5)
+        s_idx = ion.get_state_for_F(Ca43.ground_level, F=4, M_F=+4)
+        p_idx = ion.get_state_for_F(Ca43.P32, F=5, M_F=+5)
 
         rates = Rates(ion)
         detuning = ion.get_transition_frequency_for_states((s_idx, p_idx))

--- a/atomic_physics/tests/test_spin_half.py
+++ b/atomic_physics/tests/test_spin_half.py
@@ -6,7 +6,7 @@ import numpy as np
 import scipy.constants as consts
 
 from atomic_physics.core import Level
-from atomic_physics.ions import ba133
+from atomic_physics.ions.ba133 import Ba133
 
 
 def Lande_g(level: Level):
@@ -36,9 +36,9 @@ class TestSpinHalf(unittest.TestCase):
     """Test for spin-half nuclei"""
 
     def test_hyperfine(self):
-        level = ba133.ground_level
-        Ba133 = ba133.Ba133.filter_levels(level_filter=(level,))
-        ion = Ba133(0.1e-4)
+        level = Ba133.ground_level
+        factory = Ba133.filter_levels(level_filter=(level,))
+        ion = factory(0.1e-4)
 
         E_0_0 = ion.state_energies[ion.get_state_for_F(level, F=0, M_F=0)]
         E_1_0 = ion.state_energies[ion.get_state_for_F(level, F=1, M_F=0)]
@@ -48,10 +48,10 @@ class TestSpinHalf(unittest.TestCase):
         self.assertAlmostEqual(abs(E_0_0 - E_1_0) / 1e6, Ahfs / 1e6, 4)
 
     def test_zeeman(self):
-        level = ba133.ground_level
-        Ba133 = ba133.Ba133.filter_levels(level_filter=(level,))
+        level = Ba133.ground_level
+        factory = Ba133.filter_levels(level_filter=(level,))
         B = 10e-4
-        ion = Ba133(B)
+        ion = factory(B)
 
         E_1_0 = ion.state_energies[ion.get_state_for_F(level, F=1, M_F=0)]
         E_1_1 = ion.state_energies[ion.get_state_for_F(level, F=1, M_F=1)]

--- a/atomic_physics/tests/test_spont.py
+++ b/atomic_physics/tests/test_spont.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from atomic_physics.ions import ca43
+from atomic_physics.ions.ca43 import Ca43
 
 from .utils import wigner_3j, wigner_6j
 
@@ -12,7 +12,7 @@ class TestGamma(unittest.TestCase):
         """Check that, in the low-field, our scattering rates match a more direct
         calculation.
         """
-        ion = ca43.Ca43(magnetic_field=1e-8)
+        ion = Ca43(magnetic_field=1e-8)
         Gamma_ion = np.abs(ion.get_electric_multipoles()) ** 2
         Idim = int(np.rint(2 * ion.nuclear_spin + 1))
         Gamma = np.zeros((ion.num_states, ion.num_states))
@@ -65,7 +65,7 @@ class TestGamma(unittest.TestCase):
     def test_HF(self):
         """Check that, in the high-field, our scattering rates match a more
         direct calculation."""
-        ion = ca43.Ca43(magnetic_field=1000)
+        ion = Ca43(magnetic_field=1000)
         Gamma_ion = np.abs(ion.get_electric_multipoles()) ** 2
         Idim = int(np.rint(2 * ion.nuclear_spin + 1))
         Gamma = np.zeros((ion.num_states, ion.num_states))

--- a/atomic_physics/tests/test_stim.py
+++ b/atomic_physics/tests/test_stim.py
@@ -1,14 +1,14 @@
 import unittest
 
 from atomic_physics.core import Laser
-from atomic_physics.ions import ca43
+from atomic_physics.ions.ca43 import Ca43
 from atomic_physics.rate_equations import Rates
 
 
 class TestStim(unittest.TestCase):
     def test_multi_transition(self):
         """Test with lasers on multiple transitions (see #15)"""
-        ion = ca43.Ca43(magnetic_field=146e-4)
+        ion = Ca43(magnetic_field=146e-4)
         rates = Rates(ion)
         Lasers = (
             Laser("397", polarization=0, intensity=1, detuning=0),
@@ -18,7 +18,7 @@ class TestStim(unittest.TestCase):
 
     def test_multi_laser(self):
         """Test with multiple lasers on one transition"""
-        ion = ca43.Ca43(magnetic_field=146e-4)
+        ion = Ca43(magnetic_field=146e-4)
         rates = Rates(ion)
         Lasers = (
             Laser("397", polarization=0, intensity=1, detuning=0),

--- a/atomic_physics/tests/test_two_state_atom.py
+++ b/atomic_physics/tests/test_two_state_atom.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import scipy.constants as consts
 
-from atomic_physics.atoms import two_state
+from atomic_physics.atoms.two_state import TwoStateAtom, field_for_frequency
 
 
 class TestTwoStateAtom(unittest.TestCase):
@@ -11,16 +11,16 @@ class TestTwoStateAtom(unittest.TestCase):
 
     def test_frequency(self):
         w_0 = 2 * np.pi * 100e6
-        magnetic_field = two_state.field_for_frequency(w_0)
-        atom = two_state.TwoStateAtom(magnetic_field=magnetic_field)
+        magnetic_field = field_for_frequency(w_0)
+        atom = TwoStateAtom(magnetic_field=magnetic_field)
 
         np.testing.assert_allclose(
-            atom.level_data[two_state.ground_level].g_J,
+            atom.level_data[TwoStateAtom.ground_level].g_J,
             -consts.physical_constants["electron g factor"][0],
         )
         np.testing.assert_allclose(
             atom.get_transition_frequency_for_states(
-                (two_state.upper_state, two_state.lower_state)
+                (TwoStateAtom.upper_state, TwoStateAtom.lower_state)
             ),
             w_0,
         )

--- a/atomic_physics/tests/test_utils.py
+++ b/atomic_physics/tests/test_utils.py
@@ -4,7 +4,8 @@ import numpy as np
 import scipy.constants as consts
 
 from atomic_physics.core import RFDrive
-from atomic_physics.ions import ca40, ca43
+from atomic_physics.ions.ca40 import Ca40
+from atomic_physics.ions.ca43 import Ca43
 from atomic_physics.polarization import (
     PI_POLARIZATION,
     SIGMA_MINUS_POLARIZATION,
@@ -29,12 +30,12 @@ class TestUtils(unittest.TestCase):
 
     def test_rayleigh_range(self):
         waist = 33e-6
-        transition = ca43.transitions["397"]
+        transition = Ca43.transitions["397"]
         wavelength = consts.c / (transition.frequency / (2 * np.pi))
 
         np.testing.assert_allclose(
             np.pi * waist**2 / wavelength,
-            rayleigh_range(ca43.transitions["397"], waist),
+            rayleigh_range(Ca43.transitions["397"], waist),
         )
 
 
@@ -47,7 +48,7 @@ class TestFieldSensitivity(unittest.TestCase):
 
     def test_df_db(self):
         """Tests for ``utils.dF_dB``."""
-        ion = ca43.Ca43(magnetic_field=146.0942e-4)
+        ion = Ca43(magnetic_field=146.0942e-4)
 
         # [1] table E.4
         values = [
@@ -75,11 +76,11 @@ class TestFieldSensitivity(unittest.TestCase):
         ]
 
         for M4, M3, df_dB_ref in values:
-            l_index = ion.get_state_for_F(level=ca43.ground_level, F=4, M_F=M4)
-            u_index = ion.get_state_for_F(level=ca43.ground_level, F=3, M_F=M3)
+            l_index = ion.get_state_for_F(level=Ca43.ground_level, F=4, M_F=M4)
+            u_index = ion.get_state_for_F(level=Ca43.ground_level, F=3, M_F=M3)
             np.testing.assert_allclose(
                 df_dB(
-                    atom_factory=ca43.Ca43,
+                    atom_factory=Ca43,
                     states=(l_index, u_index),
                     magnetic_field=146.0942e-4,
                 )
@@ -90,15 +91,15 @@ class TestFieldSensitivity(unittest.TestCase):
 
     def test_d2f_db2(self):
         """Tests for ``utils.d2F_dB2``."""
-        ion = ca43.Ca43(magnetic_field=146.0942e-4)
+        ion = Ca43(magnetic_field=146.0942e-4)
 
         np.testing.assert_allclose(
             d2f_dB2(
-                atom_factory=ca43.Ca43,
+                atom_factory=Ca43,
                 magnetic_field=146.0942e-4,
                 states=(
-                    ion.get_state_for_F(ca43.S12, F=4, M_F=0),
-                    ion.get_state_for_F(ca43.S12, F=3, M_F=+1),
+                    ion.get_state_for_F(Ca43.S12, F=4, M_F=0),
+                    ion.get_state_for_F(Ca43.S12, F=3, M_F=+1),
                 ),
             )
             / (2 * np.pi * 1e11),
@@ -110,11 +111,11 @@ class TestFieldSensitivity(unittest.TestCase):
         """Tests for ``utils.field_insensitive_point``."""
         np.testing.assert_allclose(
             field_insensitive_point(
-                atom_factory=ca43.Ca43,
-                level_0=ca43.S12,
+                atom_factory=Ca43,
+                level_0=Ca43.S12,
                 F_0=4,
                 M_F_0=0,
-                level_1=ca43.S12,
+                level_1=Ca43.S12,
                 F_1=3,
                 M_F_1=+1,
                 magnetic_field_guess=10e-4,
@@ -136,7 +137,7 @@ class TestACZeeman(unittest.TestCase):
         Test the AC Zeeman shift for the ground level qubit in a 40Ca+ ion.
         """
         B_rf = 1e-6  # RF field of 1 uT
-        ion = ca40.Ca40.filter_levels(level_filter=(ca40.ground_level,))(
+        ion = Ca40.filter_levels(level_filter=(Ca40.ground_level,))(
             magnetic_field=10e-4
         )
 
@@ -199,9 +200,9 @@ class TestACZeeman(unittest.TestCase):
         [1] Chapter 6.
         """
         B_rf = 1e-6  # RF field of 1 uT
-        level = ca43.ground_level
-        Ca43 = ca43.Ca43.filter_levels(level_filter=(level,))
-        ion = Ca43(magnetic_field=146.0942e-4)
+        level = Ca43.ground_level
+        factory = Ca43.filter_levels(level_filter=(level,))
+        ion = factory(magnetic_field=146.0942e-4)
 
         # RF frequency calculated relative to the transition frequency of the
         # (4, 0) <-> (3, 1) qubit pair.
@@ -260,8 +261,8 @@ class TestACZeeman(unittest.TestCase):
         """Compare AC Zeeman shifts in the ground-level of 43Ca+ at 146G to values from
         [1] table 5.9.
         """
-        level = ca43.ground_level
-        ion = ca43.Ca43.filter_levels(level_filter=(level,))(magnetic_field=146.0942e-4)
+        level = Ca43.ground_level
+        ion = Ca43.filter_levels(level_filter=(level,))(magnetic_field=146.0942e-4)
         idx_qubit_0 = ion.get_state_for_F(level, F=4, M_F=0)
         idx_qubit_1 = ion.get_state_for_F(level, F=3, M_F=+1)
 
@@ -297,8 +298,8 @@ class TestACZeeman(unittest.TestCase):
         mixing) to ensure there is lots going on in these calculations to provide
         a good stress test of the code.
         """
-        level = ca43.D52
-        ion = ca43.Ca43(magnetic_field=10e-4)
+        level = Ca43.D52
+        ion = Ca43(magnetic_field=10e-4)
 
         upper = ion.get_state_for_F(level, F=3, M_F=1)  # state 65
         lower = ion.get_state_for_F(level, F=4, M_F=+1)  # state 70

--- a/atomic_physics/utils.py
+++ b/atomic_physics/utils.py
@@ -129,22 +129,22 @@ def ac_zeeman_shift_for_state(atom: Atom, state: int, drive: RFDrive) -> float:
         import numpy as np
 
         from atomic_physics.core import RFDrive
-        from atomic_physics.ions.ca40 import Ca40, ground_level
+        from atomic_physics.ions.ca40 import Ca40
         from atomic_physics.polarization import SIGMA_PLUS_POLARIZATION
         from atomic_physics.utils import ac_zeeman_shift_for_state
 
         ion = Ca40(magnetic_field=10e-4)
         w_transition = ion.get_transition_frequency_for_states(
             states=(
-                ion.get_states_for_M(level=ground_level, M=+1 / 2),
-                ion.get_states_for_M(level=ground_level, M=-1 / 2),
+                ion.get_states_for_M(level=Ca40.ground_level, M=+1 / 2),
+                ion.get_states_for_M(level=Ca40.ground_level, M=-1 / 2),
             )
         )
         w_rf = w_transition + 1e6 * 2 * np.pi  # RF is 1 MHz blue of the transition
 
         ac_zeeman_shift_for_state(
             atom=ion,
-            state=ion.get_states_for_M(level=ground_level, M=+1 / 2),
+            state=ion.get_states_for_M(level=Ca40.ground_level, M=+1 / 2),
             drive=RFDrive(frequency=w_rf, amplitude=1e-6, polarization=SIGMA_PLUS_POLARIZATION),
         )
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,11 @@
 Change Log
 ==========
 
+v2.0.3
+~~~~~~
+
+Refactor of how we define ions and atoms. We now define a subclass of ``AtomFactory`` for each atom / ion definition. Pre-defined levels are now attributes of these classes. This change is partly motivated by making it easier to write species-agnostic code (makes it easier to write things like ``factory.S12`` rather than having to access module-level attributes as well as the factory object).
+
 v2.0
 ~~~~
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -49,18 +49,18 @@ the 3D5/2 level using a 393nm laser.
    from scipy.linalg import expm
 
    from atomic_physics.core import Laser
-   from atomic_physics.ions import ca43
+   from atomic_physics.ions.ca43 import Ca43
    from atomic_physics.rate_equations import Rates
 
    t_ax = np.linspace(0, 100e-6, 100)
    intensity = 0.02  # 393 intensity
 
-   ion = ca43.Ca43(magnetic_field=146e-4)
-   stretch = ion.get_state_for_F(ca43.ground_level, F=4, M_F=+4)
+   ion = Ca43(magnetic_field=146e-4)
+   stretch = ion.get_state_for_F(Ca43.ground_level, F=4, M_F=+4)
 
    rates = Rates(ion)
    delta = ion.get_transition_frequency_for_states(
-       (stretch, ion.get_state_for_F(ca43.P32, F=5, M_F=+5))
+       (stretch, ion.get_state_for_F(Ca43.P32, F=5, M_F=+5))
    )
    lasers = (
        Laser("393", polarization=+1, intensity=intensity, detuning=delta),
@@ -72,7 +72,7 @@ the 3D5/2 level using a 393nm laser.
    shelved = np.zeros(len(t_ax))
    for idx, t in np.ndenumerate(t_ax):
        Vf = expm(trans * t) @ Vi
-       shelved[idx] = np.sum(Vf[ion.get_slice_for_level(ca43.shelf)])
+       shelved[idx] = np.sum(Vf[ion.get_slice_for_level(Ca43.shelf)])
 
    plt.plot(t_ax * 1e6, shelved)
    plt.ylabel("Shelved Population")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "atomic_physics"
-version = "2.0.2"
+version = "2.0.3"
 description = "Lightweight python library for calculations based on atomic structure"
 authors = ["hartytp <thomas.peter.harty@gmail.com>"]
 


### PR DESCRIPTION
This PR creates a subclass of `AtomFactory` for each atom / ion definition and moves the definitions of levels inside of these new factory classes.

This is partly intended as a tidy up of name spaces, but it also makes writing code that is generic over atoms easier since one can now write things like `factory.ground_level` rather than having to write `module.ground_level`.

It feels a little unsatisfactory having both an `AtomFactory` subclass and an instance of that subclass for each atom/ion definition. Perhaps this is fine - and I can't see an obviously better solution. We could revisit seeing if we can merge `Atom` and `AtomFactory`, although I forget the exact considerations which led me to separate these in the first place. Either way, I think that would be best left for a separate PR.