### PR TITLE
Add MVP OBE Solver

### DIFF
--- a/atomic_physics/bloch.py
+++ b/atomic_physics/bloch.py
@@ -1,0 +1,143 @@
+import juliacall
+import numpy as np
+import scipy.constants as consts
+
+from atomic_physics.core import Atom, Level, RFDrive
+from atomic_physics.polarization import (
+    PI_POLARIZATION,
+    SIGMA_MINUS_POLARIZATION,
+    SIGMA_PLUS_POLARIZATION,
+)
+
+jl = juliacall.newmodule("Bloch")
+jl.seval(
+    """
+    using QuantumOptics
+    using PythonCall
+
+    function make_rf_hamiltonian(
+        num_states::Int32,
+        Omegas::PythonCall.Wrap.PyArray,
+        deltas::PythonCall.Wrap.PyArray
+    )
+        basis = NLevelBasis(num_states)
+
+        Hs = QuantumOpticsBase.TimeDependentSum[]
+        for element in eachindex(Omegas)
+            if Omegas[element] == 0.
+                continue
+            end
+
+            Omega = Omegas[element]
+            delta = deltas[element]
+
+            op = 1 / 2 * Omega * transition(basis, element[1], element[2])
+            H_half = TimeDependentSum((t->exp(-1im*delta*t))=>op)
+            H = H_half + dagger(H_half)
+            push!(Hs, H)
+        end
+        return sum(Hs)
+    end
+
+    function make_ket(
+        num_states::Int32,
+        state_vector::PythonCall.Wrap.PyArray
+    )
+        basis = NLevelBasis(num_states)
+        return Ket(basis, Vector{ComplexF64}(state_vector))
+    end
+    """
+)
+
+
+class Bloch:
+    def __init__(self, atom: Atom):
+        """Optical Bloch equations.
+
+        This is implemented as a thin wrapper around the ``QuantumOptics.jl`` toolkit
+        using the ``JuliaCall`` library.
+
+        Currently, only RF (M1) transitions are supported; electric transitions and
+        spontaneous emission are not (yet) supported.
+        """
+        self.atom: Atom = atom
+        self.basis: juliacall.AnyValue = jl.NLevelBasis(np.int32(self.atom.num_states))
+
+    def H_for_rf_drive(self, level: Level, drive: RFDrive) -> juliacall.AnyValue:
+        """Returns the (time-dependent) Hamiltonian describing the interaction between
+        the atom and an RF drive.
+
+        We make the approximation that the RF drive only couples to states within a
+        single level.
+
+        :param level: the level which the RF drive couples to.
+        :param drive: the :class:`~atomic_physics.core.RFDrive`.
+        :return: the Hamiltonian. This is a JuliaCall wrapper around a ``QuantumOptics.jl``
+            `TimeDependentSum` object.
+        """
+        R = self.atom.get_magnetic_dipoles()
+        M_j, M_i = np.meshgrid(self.atom.M, self.atom.M)
+        dMs = M_i - M_j
+
+        Omegas = np.zeros(R.shape, dtype=np.complex64)
+        for dM, pol in [
+            (+1, SIGMA_PLUS_POLARIZATION),
+            (-1, SIGMA_MINUS_POLARIZATION),
+            (0, PI_POLARIZATION),
+        ]:
+            amplitude = drive.amplitude * np.vdot(drive.polarization, pol)
+
+            if amplitude == 0.0:
+                continue
+
+            pol_inds = np.triu(dMs == dM)
+            Omegas[pol_inds] = amplitude * R[pol_inds] / consts.hbar
+
+        E_j, E_i = np.meshgrid(self.atom.state_energies, self.atom.state_energies)
+        freq = E_i - E_j
+        deltas = freq - drive.frequency
+
+        return jl.make_rf_hamiltonian(
+            np.int32(self.atom.num_states),
+            np.asarray(Omegas, dtype=np.complex128),
+            np.asarray(deltas, dtype=np.float64),
+        )
+
+    def make_ket(self, state_vector: np.array) -> juliacall.AnyValue:
+        """Converts a numpy array representation of a state vector into a ``JuliaCall``
+        wrapper around a ``QuantumOptics.jl`` ``Ket`` object.
+
+        :param state_vector: array of complex amplitudes describing the atom's state.
+        :return: the corresponding ``Ket``.
+        """
+        if state_vector.shape != (self.atom.num_states,):
+            raise ValueError(
+                "Invalid state vector shape. "
+                f"Got {state_vector.shape}, expected {(1, self.atom.num_states)}"
+            )
+        return jl.make_ket(
+            np.int32(self.atom.num_states),
+            np.asarray(state_vector, dtype=np.complex128),
+        )
+
+    def solve_schroedinger(
+        self, H: juliacall.AnyValue, psi0: np.array, t: np.array
+    ) -> np.array:
+        """Integrate the time-dependent Schroedinger equation for a given Hamiltonian
+        and initial state.
+
+        :param H: the Hamiltonian.
+        :param psi0: vector of complex coefficients describing the atom's initial state.
+        :param t: vector of time points to return the atom's state at.
+        :return: ``(len(t), atom.num_states)`` array of complex coefficients describing
+            the atom's state at each time ``t``. The first dimension of the returned
+            array corresponds to points in the input vector ``t``, while the second
+            dimension corresponds to the states in the atom.
+        """
+        _, psi_t = jl.timeevolution.schroedinger_dynamic(
+            np.asarray(t, dtype=np.float64),
+            self.make_ket(psi0),
+            H,
+        )
+
+        return np.array([psi.data.to_numpy() for psi in psi_t])

--- a/atomic_physics/juliapkg.json
+++ b/atomic_physics/juliapkg.json
@@ -1,0 +1,5 @@
+{
+    "packages": {
+        "QuantumOptics": {"uuid": "6e0679c1-51ea-5a7c-ac74-d61b76210b0c", "version": "1.2"}
+    }
+}

--- a/atomic_physics/tests/test_bloch.py
+++ b/atomic_physics/tests/test_bloch.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from atomic_physics.atoms.two_state import TwoStateAtom, field_for_frequency
+from atomic_physics.bloch import Bloch
+from atomic_physics.core import RFDrive
+from atomic_physics.polarization import SIGMA_PLUS_POLARIZATION
+
+omega = 1.2451158e6
+delta = omega / 2
+
+f0 = 100e6 * 2 * np.pi
+b = field_for_frequency(f0)
+atom = TwoStateAtom(b)
+
+bloch = Bloch(atom)
+
+H = bloch.H_for_rf_drive(
+    level=TwoStateAtom.ground_level,
+    drive=RFDrive(
+        frequency=f0 - delta, amplitude=10e-6, polarization=SIGMA_PLUS_POLARIZATION
+    ),
+)
+
+t = np.linspace(0, 10e-6, 1000)
+results = bloch.solve_schroedinger(H, np.array([1, 0]), t)
+P_julia = np.abs(results[:, 0]) ** 2
+
+omega_eff = np.sqrt(omega**2 + delta**2)
+P_analytic = 1 - (omega / omega_eff * np.sin(0.5 * omega_eff * t)) ** 2
+
+np.testing.assert_allclose(P_julia, P_analytic, atol=5e-6, rtol=5e-6)

--- a/poetry.lock
+++ b/poetry.lock
@@ -277,6 +277,22 @@ files = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.17.0"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "filelock-3.17.0-py3-none-any.whl", hash = "sha256:533dc2f7ba78dc2f0f531fc6c4940addf7b70a481e269a5a3b93be94ffbe8338"},
+    {file = "filelock-3.17.0.tar.gz", hash = "sha256:ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)", "pytest (>=8.3.4)", "pytest-asyncio (>=0.25.2)", "pytest-cov (>=6)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.28.1)"]
+typing = ["typing-extensions (>=4.12.2)"]
+
+[[package]]
 name = "fonttools"
 version = "4.55.3"
 description = "Tools to manipulate font files"
@@ -415,6 +431,35 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "juliacall"
+version = "0.9.24"
+description = "Julia and Python in seamless harmony"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "juliacall-0.9.24-py3-none-any.whl", hash = "sha256:f1d7b718228c477aeba770290647f3b2d0052f683da891b4e9f88c1e1da0a394"},
+    {file = "juliacall-0.9.24.tar.gz", hash = "sha256:31bed223489b535e4e8db46bfff4596350c24f757b9c2d17296c07397f75948b"},
+]
+
+[package.dependencies]
+juliapkg = ">=0.1.8,<0.2.0"
+
+[[package]]
+name = "juliapkg"
+version = "0.1.16"
+description = "Julia version manager and package manager"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "juliapkg-0.1.16-py3-none-any.whl", hash = "sha256:def06f89ec1f27e290b6b4ad856290a8fdcfe257f002fbe1becdf3ba0ad4579c"},
+    {file = "juliapkg-0.1.16.tar.gz", hash = "sha256:f26cc314f2a3194428bf7492270b1c371194ce288806ffbac5baa0eb9468a120"},
+]
+
+[package.dependencies]
+filelock = ">=3.16,<4.0"
+semver = ">=3.0,<4.0"
 
 [[package]]
 name = "kiwisolver"
@@ -1249,6 +1294,17 @@ doc = ["intersphinx_registry", "jupyterlite-pyodide-kernel", "jupyterlite-sphinx
 test = ["Cython", "array-api-strict (>=2.0,<2.1.1)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
+name = "semver"
+version = "3.0.4"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746"},
+    {file = "semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602"},
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1534,4 +1590,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10,<3.11"
-content-hash = "60e6036135246a16aea1297d2983f9973e48ffe5787d1cace0fd906ce423a873"
+content-hash = "4eddf3e20aaa5da569b07babb7712d380ca201780eb25c81e1080934c6b01a80"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["hartytp <thomas.peter.harty@gmail.com>"]
 python = "^3.10,<3.11"
 numpy = "^1.22.0"
 scipy = "^1.7.3"
+juliacall = "^0.9.24"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
Adds an OBE solver MVP.

This initial version only supports RF (M1) transitions; electric transitions and spontaneous emission are not supported.

The implementation is based on a very thin wrapper around the `QuantumOptics.jl` package using `JuliaCall`.

TODO:
* check how we're passing arrays around - should avoid copying
* the way I'm iterating over non-zero elements of the Rabi matrix is ugly, but `findall(Omegas != 0)` wasn't working for some reason
* check definitions and sign conventions
* add an example (e.g. two tones to remind the user that Hamiltonians can be added together)
* add helper utility to Atom to calculate the field for a given rabi frequency on a given transition
* make the H generation code actually use the input level rather than just ignoring it

Currently this is extremely slow the first time the code is run, but fast the second time - 2 min on my laptop for the test on the first iteration within a second, down to 10s of ms the second time. Just importing `juliacall` takes around 5s. Importing `QuantumOptics` takes up most (~90%) of the rest, with the remaining time being compiling various bits of other code (including the juliacall wrappers). This is pretty annoying and impacts workflow.

We can shave some time off using `PackageCompiler.jl` to pre-compile `QuantumOptics.jl`. Maybe more by using `trace-compile` and using the test as a typical workflow to aide precompilation.